### PR TITLE
Implement Send for Client and AsyncClient (#71)

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -39,6 +39,10 @@ pub struct AsyncClient<N: NotificationHandler, P: ProcessHandler> {
     handler: *mut (N, P, *mut j::jack_client_t),
 }
 
+unsafe impl<N, P> Send for AsyncClient<N, P>
+    where N: NotificationHandler,
+          P: ProcessHandler { }
+
 impl<N, P> AsyncClient<N, P>
     where N: NotificationHandler,
           P: ProcessHandler

--- a/src/client/base.rs
+++ b/src/client/base.rs
@@ -131,6 +131,8 @@ impl ProcessScope {
 #[derive(Debug)]
 pub struct Client(*mut j::jack_client_t);
 
+unsafe impl Send for Client {}
+
 impl Client {
     /// The maximum length of the JACK client name string. Unlike the "C" JACK
     /// API, this does not take into account the final `NULL` character and

--- a/src/client/callbacks.rs
+++ b/src/client/callbacks.rs
@@ -115,7 +115,7 @@ pub trait NotificationHandler: Send {
     fn latency(&mut self, _: &Client, _mode: LatencyType) {}
 }
 
-pub trait ProcessHandler {
+pub trait ProcessHandler : Send {
     /// Called whenever there is work to be done.
     ///
     /// It needs to be suitable for real-time execution. That means that it cannot call functions


### PR DESCRIPTION
This PR would close issue #71 
Implemented Sync to allow passing Client and AsyncClient between threads safely (compiler allows it)