### PR TITLE
Implement std::error::Error

### DIFF
--- a/src/jack_enums.rs
+++ b/src/jack_enums.rs
@@ -27,6 +27,15 @@ pub enum Error {
     UnknownError,
 }
 
+impl std::fmt::Display for Error {
+	fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+		write!(f, "JackError: {:?}", &self) // FIXME
+	}
+}
+
+impl std::error::Error for Error {
+}
+
 /// Used by `NotificationHandler::latency()`.
 #[derive(Clone, Copy, Debug)]
 pub enum LatencyType {


### PR DESCRIPTION
This implements the [`std::error::Error`](https://doc.rust-lang.org/std/error/trait.Error.html) trait, so that easy usage of the `?` is possible. It is just a very basic implementation that uses the derived `Debug`-formatter. This could be improved (marked with a `FIXME`).