### PR TITLE
Remove Sync requirement from ProcessHandler. (#121)

### DIFF
--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -33,7 +33,7 @@ pub struct AsyncClient<N, P> {
 impl<N, P> AsyncClient<N, P>
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     /// Tell the JACK server that the program is ready to start processing audio. JACK will call the
     /// methods specified by the `NotificationHandler` and `ProcessHandler` objects.

--- a/src/client/callbacks.rs
+++ b/src/client/callbacks.rs
@@ -155,7 +155,7 @@ pub trait ProcessHandler: Send {
 unsafe extern "C" fn thread_init_callback<N, P>(data: *mut libc::c_void)
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     ctx.notification.thread_init(&ctx.client)
@@ -167,7 +167,7 @@ unsafe extern "C" fn shutdown<N, P>(
     data: *mut libc::c_void,
 ) where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     let cstr = ffi::CStr::from_ptr(reason);
@@ -184,7 +184,7 @@ unsafe extern "C" fn shutdown<N, P>(
 unsafe extern "C" fn process<N, P>(n_frames: Frames, data: *mut libc::c_void) -> libc::c_int
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     let scope = ProcessScope::from_raw(n_frames, ctx.client.raw());
@@ -194,7 +194,7 @@ where
 unsafe extern "C" fn freewheel<N, P>(starting: libc::c_int, data: *mut libc::c_void)
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     let is_starting = match starting {
@@ -207,7 +207,7 @@ where
 unsafe extern "C" fn buffer_size<N, P>(n_frames: Frames, data: *mut libc::c_void) -> libc::c_int
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     ctx.notification.buffer_size(&ctx.client, n_frames).to_ffi()
@@ -216,7 +216,7 @@ where
 unsafe extern "C" fn sample_rate<N, P>(n_frames: Frames, data: *mut libc::c_void) -> libc::c_int
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     ctx.notification.sample_rate(&ctx.client, n_frames).to_ffi()
@@ -228,7 +228,7 @@ unsafe extern "C" fn client_registration<N, P>(
     data: *mut libc::c_void,
 ) where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     let name = ffi::CStr::from_ptr(name).to_str().unwrap();
@@ -246,7 +246,7 @@ unsafe extern "C" fn port_registration<N, P>(
     data: *mut libc::c_void,
 ) where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     let register = match register {
@@ -266,7 +266,7 @@ unsafe extern "C" fn port_rename<N, P>(
 ) -> libc::c_int
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     let old_name = ffi::CStr::from_ptr(old_name).to_str().unwrap();
@@ -283,7 +283,7 @@ unsafe extern "C" fn port_connect<N, P>(
     data: *mut libc::c_void,
 ) where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     let are_connected = match connect {
@@ -297,7 +297,7 @@ unsafe extern "C" fn port_connect<N, P>(
 unsafe extern "C" fn graph_order<N, P>(data: *mut libc::c_void) -> libc::c_int
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     ctx.notification.graph_reorder(&ctx.client).to_ffi()
@@ -306,7 +306,7 @@ where
 unsafe extern "C" fn xrun<N, P>(data: *mut libc::c_void) -> libc::c_int
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     ctx.notification.xrun(&ctx.client).to_ffi()
@@ -315,7 +315,7 @@ where
 unsafe extern "C" fn latency<N, P>(mode: j::jack_latency_callback_mode_t, data: *mut libc::c_void)
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
     let mode = match mode {
@@ -354,7 +354,7 @@ pub struct CallbackContext<N, P> {
 impl<N, P> CallbackContext<N, P>
 where
     N: 'static + Send + Sync + NotificationHandler,
-    P: 'static + Send + Sync + ProcessHandler,
+    P: 'static + Send + ProcessHandler,
 {
     pub unsafe fn from_raw<'a>(ptr: *mut libc::c_void) -> &'a mut CallbackContext<N, P> {
         debug_assert!(!ptr.is_null());

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -61,7 +61,7 @@ impl Client {
     ) -> Result<AsyncClient<N, P>, Error>
     where
         N: 'static + Send + Sync + NotificationHandler,
-        P: 'static + Send + Sync + ProcessHandler,
+        P: 'static + Send + ProcessHandler,
     {
         AsyncClient::new(self, notification_handler, process_handler)
     }

--- a/src/jack_enums.rs
+++ b/src/jack_enums.rs
@@ -40,6 +40,15 @@ pub enum LatencyType {
     Playback,
 }
 
+impl LatencyType {
+    pub fn to_ffi(self) -> libc::c_uint {
+        match self {
+            LatencyType::Playback => jack_sys::JackPlaybackLatency,
+            LatencyType::Capture => jack_sys::JackCaptureLatency,
+        }
+    }
+}
+
 /// Specify an option, either to continue processing, or to stop.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Control {


### PR DESCRIPTION
This partially reverts 356aec6c.

A ProcessHandler is moved into `activate_async` and thus can only be used by a single client.
While in Jack2, process_callbacks of *different* clients can indeed run concurrently, the process_callback of a single client can not be concurrent with itself.

(The process_callback of a single client can run concurrently with the notification callbacks of the same client, and I am not sure whether the *notification* callback is also guaranteed to be non-self-concurrent.)