### PR TITLE
Correct jack-sys README formatting

### DIFF
--- a/jack-sys/README.md
+++ b/jack-sys/README.md
@@ -1,4 +1,7 @@
-#jack-sys [![crates.io](https://img.shields.io/crates/v/jack-sys.svg)](https://crates.io/crates/jack-sys)
-Low-level bindings for the [JACK Audio Connection Kit](http://jackaudio.org/). Generated using [rust-bindgen](https://github.com/crabtw/rust-bindgen).
+# jack-sys 
+
+[![crates.io](https://img.shields.io/crates/v/jack-sys.svg)](https://crates.io/crates/jack-sys)
+
+Low-level bindings for the [JACK Audio Connection Kit](http://jackaudio.org/). Generated using [rust-bindgen](https://github.com/rust-lang/rust-bindgen).
 
 Requires JACK to be installed on the system.


### PR DESCRIPTION
First, thank you for your work on this repo!  I've been writing a jack utility this week, and this repo allowed me to do it in rust :slightly_smiling_face: 

I noticed the `jack-sys` README had some formatting issues, and an invalid link to `rust-bindgen`, so went ahead and fixed those.  Take care!