### PR TITLE
Added null terminator to UNIX shared library name.

### DIFF
--- a/jack-sys/src/lib.rs
+++ b/jack-sys/src/lib.rs
@@ -1062,7 +1062,7 @@ extern "C" {
 const jack_lib: &'static str = "libjack.dll";
 
 #[cfg(unix)]
-const jack_lib: &'static str = "libjack.so";
+const jack_lib: &'static str = "libjack.so\0";
 
 type jack_get_cycle_times_t = unsafe extern "C" fn(
     client: *const jack_client_t,


### PR DESCRIPTION
This eliminates an allocation in the callback on first call to `jack_get_cycle_times` due to `libloading` needing to null terminate the library name itself.

I didn't do the same to the Windows version because, currently, `libloading` allocates a new buffer for the library file name no matter what; [see here.](https://github.com/nagisa/rust_libloading/blob/1de6189e47aef48d5fbd994063f2e22b94af4e65/src/os/windows/mod.rs#L131)

Tested by using a [custom global allocator](https://github.com/ischeinkman/redes/blob/master/src/malloc.rs) that panics in the RT thread. 

