### PR TITLE
transport query and control

### DIFF
--- a/examples/set_transport.rs
+++ b/examples/set_transport.rs
@@ -1,0 +1,93 @@
+use std::env;
+
+fn main() {
+    let (client, _status) =
+        jack::Client::new("rust_jack_trans", jack::ClientOptions::NO_START_SERVER).unwrap();
+
+    let transport = client.transport();
+
+    let usage = || {
+        let commands = [
+            "start",
+            "stop",
+            "bpm <value>",
+            "sig <numerator> <denominator>",
+            "locate <bar> <beat> <tick>",
+        ];
+        println!("usage:");
+        for cmd in commands.iter() {
+            println!("\t {} {}", env::args().nth(0).unwrap(), cmd);
+        }
+    };
+
+    if env::args().len() == 1 {
+        usage();
+    } else {
+        let jack::TransportStatePosition { mut pos, state: _ } =
+            transport.query().expect("failed to query transport");
+
+        let mut bbt = pos.bbt().unwrap_or(jack::TransportBBT::default());
+        pos.set_frame(pos.frame() + 44100);
+
+        let mut new_bbt = None;
+        let mut args = env::args().skip(1);
+        let cmd = args.next().expect("failed to get command").clone();
+        match cmd.as_str() {
+            "start" => transport.start().expect("failed to start"),
+            "stop" => transport.stop().expect("failed to stop"),
+            "bpm" => {
+                new_bbt = Some(
+                    bbt.with_bpm(
+                        args.next()
+                            .expect("failed to get bpm value")
+                            .parse::<f64>()
+                            .expect("failed to convert"),
+                    ),
+                );
+            }
+            "locate" => {
+                new_bbt = Some(
+                    bbt.with_bbt(
+                        args.next()
+                            .expect("failed to get bar value")
+                            .parse::<usize>()
+                            .expect("failed to convert"),
+                        args.next()
+                            .expect("failed to get beat value")
+                            .parse::<usize>()
+                            .expect("failed to convert"),
+                        args.next()
+                            .expect("failed to get tick value")
+                            .parse::<usize>()
+                            .expect("failed to convert"),
+                    ),
+                );
+            }
+            "sig" => {
+                new_bbt = Some(
+                    bbt.with_timesig(
+                        args.next()
+                            .expect("failed to get timesig numerator")
+                            .parse::<f32>()
+                            .expect("failed to convert"),
+                        args.next()
+                            .expect("failed to get timesig denominator")
+                            .parse::<f32>()
+                            .expect("failed to convert"),
+                    ),
+                );
+            }
+            c @ _ => {
+                println!("unknown command {}", c);
+                usage();
+                return;
+            }
+        };
+
+        if let Some(bbt) = new_bbt {
+            let bbt = bbt.validated().expect("transport bbt failed to validate");
+            pos.set_bbt(Some(bbt)).expect("error settting bbt");
+            transport.reposition(&pos).expect("failed to reposition");
+        }
+    }
+}

--- a/examples/show_transport.rs
+++ b/examples/show_transport.rs
@@ -1,0 +1,70 @@
+use std::io;
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+fn main() {
+    // Create client
+    let (client, _status) =
+        jack::Client::new("rust_jack_trans", jack::ClientOptions::NO_START_SERVER).unwrap();
+
+    let transport = client.transport();
+    let stop = Arc::new(AtomicBool::new(false));
+
+    let show = {
+        let stop = stop.clone();
+        std::thread::spawn(move || {
+            let mut state_last: Option<jack::TransportStatePosition> = None;
+            while !stop.load(Ordering::Relaxed) {
+                std::thread::sleep(std::time::Duration::from_millis(10));
+                if let Ok(state) = transport.query() {
+                    if state_last
+                        .as_ref()
+                        .map_or_else(|| true, |l| l.state != state.state)
+                    {
+                        println!("{:?}", state.state);
+                    };
+                    if let Some(mut bbt) = state.pos.bbt() {
+                        let print = if let Some(last) = &state_last {
+                            if let Some(mut last) = last.pos.bbt() {
+                                //zero out some details so we can just compare directly
+                                bbt.tick = 0;
+                                bbt.bar_start_tick = 0.0;
+                                last.tick = 0;
+                                last.bar_start_tick = 0.0;
+                                bbt != last
+                            } else {
+                                true
+                            }
+                        } else {
+                            true
+                        };
+                        if print {
+                            println!(
+                                "bar {} beat {} bpm {} sig: {}/{} tpb {}",
+                                bbt.bar,
+                                bbt.beat,
+                                bbt.bpm,
+                                bbt.sig_num,
+                                bbt.sig_denom,
+                                bbt.ticks_per_beat
+                            );
+                        }
+                    }
+                    state_last = Some(state);
+                } else {
+                    eprint!("couldn't get state");
+                    break;
+                }
+            }
+        })
+    };
+
+    // Wait for user input to quit
+    println!("Press enter/return to quit...");
+    let mut user_input = String::new();
+    io::stdin().read_line(&mut user_input).ok();
+    stop.store(true, Ordering::Relaxed);
+    show.join().expect("failed to join");
+}

--- a/examples/show_transport.rs
+++ b/examples/show_transport.rs
@@ -19,12 +19,14 @@ fn main() {
             while !stop.load(Ordering::Relaxed) {
                 std::thread::sleep(std::time::Duration::from_millis(10));
                 if let Ok(state) = transport.query() {
+                    //print if state has changed
                     if state_last
                         .as_ref()
                         .map_or_else(|| true, |l| l.state != state.state)
                     {
                         println!("{:?}", state.state);
                     };
+                    //print if bbt structure changes (ignoring tick and bar_start_tick)
                     if let Some(mut bbt) = state.pos.bbt() {
                         let print = if let Some(last) = &state_last {
                             if let Some(mut last) = last.pos.bbt() {

--- a/ffi_completeness.md
+++ b/ffi_completeness.md
@@ -80,6 +80,11 @@
 `jack_set_thread_init_callback`
 `jack_set_xrun_callback`
 `jack_time_to_frames`
+`jack_transport_locate`
+`jack_transport_query`
+`jack_transport_reposition`
+`jack_transport_start`
+`jack_transport_stop`
 
 # FFI Unused
 `jack_acquire_real_time_scheduling`
@@ -145,11 +150,6 @@
 `jack_set_timebase_callback`
 `jack_set_transport_info`
 `jack_thread_wait`
-`jack_transport_locate`
-`jack_transport_query`
-`jack_transport_reposition`
-`jack_transport_start`
-`jack_transport_stop`
 `jackctl_driver_get_name`
 `jackctl_driver_get_parameters`
 `jackctl_driver_get_type`

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -4,6 +4,7 @@ use std::{ffi, fmt, ptr};
 
 use crate::client::common::{sleep_on_test, CREATE_OR_DESTROY_CLIENT_MUTEX};
 use crate::jack_utils::collect_strs;
+use crate::transport::Transport;
 use crate::{
     AsyncClient, ClientOptions, ClientStatus, Error, Frames, NotificationHandler, Port, PortFlags,
     PortId, PortSpec, ProcessHandler, Time, Unowned,
@@ -451,6 +452,17 @@ impl Client {
     /// This is mostly for use within the jack crate itself.
     pub unsafe fn from_raw(p: *mut j::jack_client_t) -> Self {
         Client(p, Arc::default())
+    }
+
+    /// Get a `Transport` object associated with this client.
+    ///
+    /// # Remarks
+    /// * The transport methods will only work during this client's lifetime.
+    pub fn transport(&self) -> Transport {
+        Transport {
+            client_ptr: self.0,
+            client_life: Arc::downgrade(&self.1),
+        }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,6 +48,9 @@ pub use crate::port::{
 };
 pub use crate::primitive_types::{Frames, PortId, Time};
 pub use crate::ringbuffer::{RingBuffer, RingBufferReader, RingBufferWriter};
+pub use crate::transport::{
+    Transport, TransportBBT, TransportPosition, TransportState, TransportStatePosition,
+};
 
 /// Create and manage client connections to a JACK server.
 mod client;
@@ -68,6 +71,9 @@ mod port;
 
 /// Platform independent types.
 mod primitive_types;
+
+/// Transport.
+mod transport;
 
 /// Return JACK's current system time in microseconds, using the JACK clock
 /// source.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,8 @@ pub use crate::port::{
 pub use crate::primitive_types::{Frames, PortId, Time};
 pub use crate::ringbuffer::{RingBuffer, RingBufferReader, RingBufferWriter};
 pub use crate::transport::{
-    Transport, TransportBBT, TransportPosition, TransportState, TransportStatePosition,
+    Transport, TransportBBT, TransportBBTValidationError, TransportPosition, TransportState,
+    TransportStatePosition,
 };
 
 /// Create and manage client connections to a JACK server.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -17,7 +17,7 @@ pub struct Transport {
 pub struct TransportPosition(j::jack_position_t);
 
 /// A representation of transport state.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum TransportState {
     Stopped,
     Rolling,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -197,6 +197,10 @@ impl Transport {
     }
 }
 
+//all exposed methods are realtime safe
+unsafe impl Send for Transport {}
+unsafe impl Sync for Transport {}
+
 impl TransportPosition {
     /// Query to see if the BarBeatsTick data is valid.
     pub fn valid_bbt(&self) -> bool {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -297,8 +297,8 @@ impl TransportPosition {
 
     /// Get the BarBeatsTick data if it is valid.
     pub fn bbt(&self) -> Option<TransportBBT> {
-        if self.valid_bbt() && self.0.bar > 0 && self.0.beat > 0 && self.0.tick >= 0 {
-            Some(TransportBBT {
+        if self.valid_bbt() {
+            TransportBBT {
                 bar: self.0.bar as _,
                 beat: self.0.beat as _,
                 tick: self.0.tick as _,
@@ -307,7 +307,9 @@ impl TransportPosition {
                 ticks_per_beat: self.0.ticks_per_beat,
                 bpm: self.0.beats_per_minute,
                 bar_start_tick: self.0.bar_start_tick,
-            })
+            }
+            .validated()
+            .ok()
         } else {
             None
         }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,232 @@
+use jack_sys as j;
+
+pub struct Transport {
+    client_ptr: *mut j::jack_client_t,
+}
+
+#[repr(transparent)]
+pub struct TransportPosition(j::jack_position_t);
+
+#[derive(Debug, Clone, Copy)]
+pub enum TransportState {
+    Stopped,
+    Rolling,
+    Starting,
+}
+
+pub struct TransportStatePosition {
+    pub pos: TransportPosition,
+    pub state: TransportState,
+}
+
+pub struct TransportBBT {
+    /// Time signature bar, 1 or more.
+    pub bar: usize,
+    /// Time signature beat, 1 and less than sig_num.
+    pub beat: usize,
+    /// current tick-within-beat
+    /// # Remarks
+    /// * Should be >= 0 and < ticks_per_beat: the first tick is tick 0.
+    pub tick: usize,
+    /// Time Signature "numerator". Jack calls this `beats_per_bar`.
+    pub sig_num: f32,
+    /// Time Signature "denominator". Jack calls this `beat_type`.
+    pub sig_denom: f32,
+    /// Number of ticks within a beat.
+    /// # Remarks
+    /// * Usually a moderately large integer with many denominators, such as 1920.0
+    pub ticks_per_beat: f64,
+    /// BPM, quantized to block size. This means when the tempo is not constant within this block,
+    /// the BPM value should adapted to compensate for this. This is different from most fields in
+    /// this struct, which specify the value at the beginning of the block rather than an average.
+    pub bpm: f64,
+
+    /// Number of ticks that have elapsed between frame 0 and the first beat of the current measure.
+    pub bar_start_tick: f64,
+}
+
+impl Transport {
+    /// Start the JACK transport rolling.
+    ///
+    /// # Remarks
+    ///
+    /// * Any client can make this request at any time.
+    /// * It takes effect no sooner than the next process cycle, perhaps later if there are
+    /// slow-sync clients.
+    /// * This function is realtime-safe.
+    pub fn start(&self) {
+        unsafe {
+            j::jack_transport_start(self.client_ptr);
+        }
+    }
+
+    /// Stop the JACK transport.
+    ///
+    /// # Remarks
+    ///
+    /// * Any client can make this request at any time.
+    /// * It takes effect on the next process cycle.
+    /// * This function is realtime-safe.
+    pub fn stop(&self) {
+        unsafe {
+            j::jack_transport_stop(self.client_ptr);
+        }
+    }
+
+    /// Request a new transport position.
+    ///
+    /// # Arguments
+    ///
+    /// * `pos` - requested new transport position.
+    ///
+    /// # Remarks
+    ///
+    /// * May be called at any time by any client.
+    /// * The new position takes effect in two process cycles.
+    /// * If there are slow-sync clients and the transport is already rolling, it will enter the `TransportState::Starting` state and begin invoking their sync_callbacks until ready.
+    /// * This function is realtime-safe.
+    pub fn reposition(&self, pos: &TransportPosition) -> Result<(), ()> {
+        Self::to_result(unsafe {
+            j::jack_transport_reposition(
+                self.client_ptr,
+                std::mem::transmute::<&TransportPosition, *const j::jack_position_t>(pos),
+            )
+        })
+    }
+
+    /// Reposition the transport to a new frame number.
+    ///
+    /// # Arguments
+    ///
+    /// * `frame` - frame number of new transport position.
+    ///
+    /// # Remarks
+    ///
+    /// * May be called at any time by any client.
+    /// * The new position takes effect in two process cycles.
+    /// * If there are slow-sync clients and the transport is already rolling, it will enter the JackTransportStarting state and begin invoking their sync_callbacks until ready.
+    /// * This function is realtime-safe.
+    pub fn locate(&self, frame: crate::Frames) -> Result<(), ()> {
+        Self::to_result(unsafe { j::jack_transport_locate(self.client_ptr, frame) })
+    }
+
+    //helper to convert to TransportState
+    fn to_state(state: j::jack_transport_state_t) -> TransportState {
+        match state {
+            j::JackTransportStopped => TransportState::Stopped,
+            j::JackTransportStarting => TransportState::Starting,
+            _ => TransportState::Rolling,
+        }
+    }
+
+    //helper to create generic error from jack response
+    fn to_result(v: ::libc::c_int) -> Result<(), ()> {
+        if v == 0 {
+            Ok(())
+        } else {
+            Err(())
+        }
+    }
+
+    /// Query the current transport state and position.
+    ///
+    /// # Remarks
+    ///
+    /// * This function is realtime-safe, and can be called from any thread.
+    /// * If called from the process thread, `pos` corresponds to the first frame of the current cycle and the state returned is valid for the entire cycle.
+    pub fn query(&self) -> TransportStatePosition {
+        let mut pos: std::mem::MaybeUninit<TransportPosition> = std::mem::MaybeUninit::zeroed();
+        let state = Self::to_state(unsafe {
+            j::jack_transport_query(
+                self.client_ptr,
+                std::mem::transmute::<*mut TransportPosition, *mut j::jack_position_t>(
+                    pos.as_mut_ptr(),
+                ),
+            )
+        });
+        TransportStatePosition {
+            pos: unsafe { pos.assume_init() },
+            state,
+        }
+    }
+
+    /// Query the current transport state.
+    ///
+    /// # Remarks
+    ///
+    /// * This function is realtime-safe, and can be called from any thread.
+    /// * If called from the process thread, the state returned is valid for the entire cycle.
+    pub fn query_state(&self) -> TransportState {
+        Self::to_state(unsafe { j::jack_transport_query(self.client_ptr, std::ptr::null_mut()) })
+    }
+}
+
+impl TransportPosition {
+    /// Query to see if the BarBeatsTick data is valid.
+    pub fn valid_bbt(&self) -> bool {
+        (self.0.valid & j::JackPositionBBT) != 0
+    }
+
+    /// Query to see if the frame offset of BarBeatsTick data is valid.
+    pub fn valid_bbt_frame_offset(&self) -> bool {
+        (self.0.valid & j::JackBBTFrameOffset) != 0
+    }
+
+    /*
+    /// Query to see if the Timecode data is valid.
+    pub fn valid_timecode(&self) -> bool {
+        (self.0.valid & j::JackPositionTimecode) != 0
+    }
+
+    /// Query to see if the Audio/Video ratio is valid.
+    pub fn valid_avr(&self) -> bool {
+        (self.0.valid & j::JackAudioVideoRatio) != 0
+    }
+
+    /// Query to see if the Video frame offset is valid.
+    pub fn valid_video_frame_offset(&self) -> bool {
+        (self.0.valid & j::JackVideoFrameOffset) != 0
+    }
+    */
+
+    /// Get the frame number on the transport timeline.
+    ///
+    /// # Remarks
+    /// * This is not the same as what jack_frame_time returns.
+    pub fn frame(&self) -> crate::Frames {
+        self.0.frame
+    }
+
+    /// Get the BarBeatsTick data if it is valid.
+    pub fn bbt(&self) -> Option<TransportBBT> {
+        if self.valid_bbt() && self.0.bar > 0 && self.0.beat > 0 && self.0.tick >= 0 {
+            Some(TransportBBT {
+                bar: self.0.bar as _,
+                beat: self.0.bar as _,
+                tick: self.0.tick as _,
+                sig_num: self.0.beats_per_bar,
+                sig_denom: self.0.beat_type,
+                ticks_per_beat: self.0.ticks_per_beat,
+                bpm: self.0.beats_per_minute,
+                bar_start_tick: self.0.bar_start_tick,
+            })
+        } else {
+            None
+        }
+    }
+
+    /// Get the frame offset for the BBT fields.
+    ///
+    /// # Remarks
+    ///
+    /// * Should be assumed to be 0 if `None`.
+    /// * If this value is Some(0), the bbt time refers to the first frame of this cycle.
+    /// * If the value is positive, the bbt time refers to a frame that many frames **before** the start of the cycle.
+    pub fn bbt_offset(&self) -> Option<crate::Frames> {
+        if self.valid_bbt_frame_offset() {
+            Some(self.0.bbt_offset)
+        } else {
+            None
+        }
+    }
+}

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -149,13 +149,8 @@ impl Transport {
     //helper to create generic error from jack response
     fn to_result<R>(v: Result<::libc::c_int>, r: R) -> Result<R> {
         match v {
-            Ok(v) => {
-                if v == 0 {
-                    Ok(r)
-                } else {
-                    Err(crate::Error::UnknownError)
-                }
-            }
+            Ok(0) => Ok(r),
+            Ok(_) => Err(crate::Error::UnknownError),
             Err(e) => Err(e),
         }
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -31,6 +31,7 @@ pub struct TransportStatePosition {
 }
 
 /// Transport Bar Beat Tick data.
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub struct TransportBBT {
     /// Time signature bar, 1 or more.
     pub bar: usize,
@@ -365,5 +366,47 @@ impl Default for TransportPosition {
     fn default() -> Self {
         //safe to zero
         unsafe { std::mem::MaybeUninit::zeroed().assume_init() }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    mod position {
+        use crate::TransportPosition;
+        #[test]
+        fn default() {
+            let p: TransportPosition = Default::default();
+            assert!(!p.valid_bbt());
+            assert!(!p.valid_bbt_frame_offset());
+            assert_eq!(p.frame(), 0);
+            assert_eq!(p.bbt(), None);
+            assert_eq!(p.bbt_offset(), None);
+            assert_eq!(p.frame_rate(), None);
+            assert_eq!(p.usecs(), None);
+        }
+
+        #[test]
+        fn usecs() {
+            let mut p: TransportPosition = Default::default();
+            assert_eq!(p.usecs(), None);
+            p.0.usecs = 1;
+            assert_eq!(p.usecs(), Some(1));
+            p.0.usecs = 0;
+            assert_eq!(p.usecs(), None);
+            p.0.usecs = 2084;
+            assert_eq!(p.usecs(), Some(2084));
+        }
+
+        #[test]
+        fn frame_rate() {
+            let mut p: TransportPosition = Default::default();
+            assert_eq!(p.frame_rate(), None);
+            p.0.frame_rate = 44100;
+            assert_eq!(p.frame_rate(), Some(44100));
+            p.0.frame_rate = 0;
+            assert_eq!(p.frame_rate(), None);
+            p.0.frame_rate = 48000;
+            assert_eq!(p.frame_rate(), Some(48000));
+        }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -356,6 +356,22 @@ impl TransportPosition {
     }
 }
 
+impl std::fmt::Debug for TransportPosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut s = f.debug_struct("TransportPosition");
+        let mut d = s
+            .field("unique_1", unsafe { &self.0.unique_1 })
+            .field("usecs", unsafe { &self.0.usecs })
+            .field("frame", unsafe { &self.0.frame })
+            .field("frame_rate", unsafe { &self.0.frame_rate })
+            .field("valid", &format!("{:#b}", { self.0.valid }));
+        if let Some(bbt) = self.bbt() {
+            d = d.field("bbt", &bbt);
+        }
+        d.finish()
+    }
+}
+
 impl TransportBBT {
     /// Set bar, beat, tick
     ///

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -25,6 +25,7 @@ pub enum TransportState {
 }
 
 /// A helper struct encapsulating both `TransportState` and `TransportPosition`.
+#[derive(Debug)]
 pub struct TransportStatePosition {
     pub pos: TransportPosition,
     pub state: TransportState,

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -141,6 +141,7 @@ impl Transport {
         match state {
             j::JackTransportStopped => TransportState::Stopped,
             j::JackTransportStarting => TransportState::Starting,
+            //the JackTransportLooping state is no longer used
             _ => TransportState::Rolling,
         }
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -412,9 +412,10 @@ impl TransportBBT {
     /// use jack::TransportBBT;
     /// let bbt = TransportBBT::default().with_bbt(4, 2, 14).validated();
     /// assert!(bbt.is_ok());
-    /// assert_eq!(bbt.unwrap().bar, 4);
-    /// assert_eq!(bbt.unwrap().beat, 2);
-    /// assert_eq!(bbt.unwrap().tick, 14);
+    /// let bbt = bbt.unwrap();
+    /// assert_eq!(bbt.bar, 4);
+    /// assert_eq!(bbt.beat, 2);
+    /// assert_eq!(bbt.tick, 14);
     /// ```
     pub fn with_bbt<'a>(&'a mut self, bar: usize, beat: usize, tick: usize) -> &'a mut Self {
         self.bar = bar;

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -4,7 +4,7 @@ use crate::{Frames, Time};
 use jack_sys as j;
 use std::sync::Weak;
 
-type Result<T> = ::std::result::Result<T, crate::Error>;
+pub type Result<T> = ::std::result::Result<T, crate::Error>;
 
 /// A structure for querying and manipulating the JACK transport.
 pub struct Transport {


### PR DESCRIPTION
No slow sync or timebase master yet, but these bindings give the ability to get transport information and control the transport.

I changed some naming a bit to make more sense to me, but if others thing that we should change those names back (sig_num, sig_denom, etc) I'm willing to.

The `TransportBBT` struct can act like a builder, it does allow you to set it into an invalid state, but there is a validator so I figured that was good enough. The validator could use more error messages but the jack::Error enum didn't provide for that so it just returns a generic error when, for instance, a beat value is out of range.