### PR TITLE
optional metadata support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ libc = "0.2"
 
 [dev-dependencies]
 crossbeam-channel = "0.5"
+
+[features]
+default = []
+metadata = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["jack", "realtime", "audio", "midi"]
 
 [dependencies]
 bitflags = "1.2"
-jack-sys = { path = "./jack-sys", version = "0.2" }
+jack-sys = { path = "./jack-sys", version = "0.2.2" }
 lazy_static = "1.4"
 libc = "0.2"
 

--- a/ffi_completeness.md
+++ b/ffi_completeness.md
@@ -85,7 +85,6 @@
 `jack_transport_reposition`
 `jack_transport_start`
 `jack_transport_stop`
-`jack_get_version_string`
 `jack_client_get_uuid`
 `jack_uuid_parse`
 `jack_uuid_unparse`
@@ -119,6 +118,7 @@
 `jack_get_transport_info`
 `jack_get_uuid_for_client_name`
 `jack_get_version`
+`jack_get_version_string`
 `jack_get_xrun_delayed_usecs`
 `jack_info` - causes link error
 `jack_internal_client_handle`

--- a/ffi_completeness.md
+++ b/ffi_completeness.md
@@ -85,11 +85,22 @@
 `jack_transport_reposition`
 `jack_transport_start`
 `jack_transport_stop`
+`jack_get_version_string`
+`jack_client_get_uuid`
+`jack_uuid_parse`
+`jack_uuid_unparse`
+`jack_get_all_properties`
+`jack_get_properties`
+`jack_get_property`
+`jack_remove_all_properties`
+`jack_remove_properties`
+`jack_remove_property`
+`jack_set_property_change_callback`
+`jack_set_property`
 
 # FFI Unused
 `jack_acquire_real_time_scheduling`
 `jack_client_create_thread`
-`jack_client_get_uuid`
 `jack_client_has_session_callback`
 `jack_client_kill_thread`
 `jack_client_max_real_time_priority`
@@ -101,16 +112,12 @@
 `jack_drop_real_time_scheduling`
 `jack_error` - causes link error
 `jack_free_description`
-`jack_get_all_properties`
 `jack_get_client_pid`
 `jack_get_current_transport_frame`
 `jack_get_internal_client_name`
 `jack_get_max_delayed_usecs`
-`jack_get_properties`
-`jack_get_property`
 `jack_get_transport_info`
 `jack_get_uuid_for_client_name`
-`jack_get_version_string`
 `jack_get_version`
 `jack_get_xrun_delayed_usecs`
 `jack_info` - causes link error
@@ -130,9 +137,6 @@
 `jack_port_uuid`
 `jack_recompute_total_latencies`
 `jack_release_timebase`
-`jack_remove_all_properties`
-`jack_remove_properties`
-`jack_remove_property`
 `jack_reserve_client_name`
 `jack_reset_max_delayed_usecs`
 `jack_ringbuffer_reset_size`
@@ -141,8 +145,6 @@
 `jack_session_notify`
 `jack_session_reply`
 `jack_set_process_thread`
-`jack_set_property_change_callback`
-`jack_set_property`
 `jack_set_session_callback`
 `jack_set_sync_callback`
 `jack_set_sync_timeout`
@@ -190,6 +192,11 @@
 `jackctl_server_unload_internal`
 `jackctl_setup_signals`
 `jackctl_wait_signals`
+`jack_uuid_to_index`
+`jack_uuid_compare`
+`jack_uuid_copy`
+`jack_uuid_clear`
+`jack_uuid_empty`
 
 # FFI Deprecated
 `jack_client_new`

--- a/jack-sys/Cargo.toml
+++ b/jack-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jack-sys"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2018"
 authors = ["Patrick Reisert"]
 description = "Low-level binding to the JACK audio API."

--- a/jack-sys/src/lib.rs
+++ b/jack-sys/src/lib.rs
@@ -1058,6 +1058,20 @@ extern "C" {
     ) -> ::libc::size_t;
     pub fn jack_ringbuffer_write_advance(rb: *mut jack_ringbuffer_t, cnt: ::libc::size_t) -> ();
     pub fn jack_ringbuffer_write_space(rb: *const jack_ringbuffer_t) -> ::libc::size_t;
+
+}
+
+extern "C" {
+    pub fn jack_uuid_to_index(arg1: jack_uuid_t) -> u32;
+    pub fn jack_uuid_compare(arg1: jack_uuid_t, arg2: jack_uuid_t) -> ::std::os::raw::c_int;
+    pub fn jack_uuid_copy(dst: *mut jack_uuid_t, src: jack_uuid_t);
+    pub fn jack_uuid_clear(arg1: *mut jack_uuid_t);
+    pub fn jack_uuid_parse(
+        buf: *const ::std::os::raw::c_char,
+        arg1: *mut jack_uuid_t,
+    ) -> ::std::os::raw::c_int;
+    pub fn jack_uuid_unparse(arg1: jack_uuid_t, buf: *mut ::std::os::raw::c_char);
+    pub fn jack_uuid_empty(arg1: jack_uuid_t) -> ::std::os::raw::c_int;
 }
 
 // Load optional functions:

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -170,7 +170,7 @@ impl Client {
         }
     }
 
-    /// Get the name of a client but its numeric uuid.
+    /// Get the name of a client by its numeric uuid.
     #[cfg(feature = "metadata")]
     pub fn name_by_uuid(&self, uuid: j::jack_uuid_t) -> Option<String> {
         let mut uuid_s = ['\0' as _; 37]; //jack_uuid_unparse expects an array of length 37
@@ -180,7 +180,7 @@ impl Client {
         }
     }
 
-    /// Get the name of a client but its `&str` uuid.
+    /// Get the name of a client by its `&str` uuid.
     pub fn name_by_uuid_str(&self, uuid: &str) -> Option<String> {
         let uuid = ffi::CString::new(uuid).unwrap();
         unsafe { self.name_by_uuid_raw(uuid.as_ptr()) }

--- a/src/client/client.rs
+++ b/src/client/client.rs
@@ -4,7 +4,7 @@ use std::{ffi, fmt, ptr};
 
 use crate::client::common::{sleep_on_test, CREATE_OR_DESTROY_CLIENT_MUTEX};
 use crate::jack_utils::collect_strs;
-use crate::properties::{property_changed, PropertyChangeHandler};
+use crate::properties::PropertyChangeHandler;
 use crate::transport::Transport;
 use crate::{
     AsyncClient, ClientOptions, ClientStatus, Error, Frames, NotificationHandler, Port, PortFlags,
@@ -125,6 +125,7 @@ impl Client {
     /// # Remarks
     ///
     /// * Deallocates, not realtime safe.
+    #[cfg(feature = "metadata")]
     pub fn uuid(&self) -> j::jack_uuid_t {
         unsafe {
             let mut uuid: j::jack_uuid_t = Default::default();
@@ -170,6 +171,7 @@ impl Client {
     }
 
     /// Get the name of a client but its numeric uuid.
+    #[cfg(feature = "metadata")]
     pub fn name_by_uuid(&self, uuid: j::jack_uuid_t) -> Option<String> {
         let mut uuid_s = ['\0' as _; 37]; //jack_uuid_unparse expects an array of length 37
         unsafe {
@@ -502,6 +504,7 @@ impl Client {
     ///
     /// # Panics
     /// Calling this method more than once on any given client with cause a panic.
+    #[cfg(feature = "metadata")]
     pub fn register_property_change_handler<H: PropertyChangeHandler + 'static>(
         &mut self,
         handler: H,
@@ -512,7 +515,7 @@ impl Client {
             self.2 = Some(Box::from_raw(handler));
             if j::jack_set_property_change_callback(
                 self.raw(),
-                Some(property_changed::<H>),
+                Some(crate::properties::property_changed::<H>),
                 std::mem::transmute::<_, _>(handler),
             ) == 0
             {

--- a/src/client/test.rs
+++ b/src/client/test.rs
@@ -154,3 +154,40 @@ fn client_can_use_ringbuffer() {
 
     assert_eq!(outbuf[..num], buf[..]);
 }
+
+#[test]
+fn client_uuid() {
+    let (c1, _) = open_test_client("client1");
+    let (c2, _) = open_test_client("client2");
+
+    let uuid1 = c1.uuid();
+    let uuid2 = c2.uuid();
+    assert_ne!(uuid1, uuid2);
+    assert_ne!(0, uuid1);
+    assert_ne!(0, uuid2);
+
+    let uuid1s = c1.uuid_string();
+    let uuid2s = c2.uuid_string();
+    assert_ne!(uuid1s, uuid2s);
+
+    assert_eq!(c1.name_by_uuid(0), None);
+    assert_eq!(c2.name_by_uuid(0), None);
+
+    assert_eq!(c1.name_by_uuid(uuid1), Some("client1".to_string()));
+    assert_eq!(c2.name_by_uuid(uuid1), Some("client1".to_string()));
+    assert_eq!(c1.name_by_uuid_str(&uuid1s), Some("client1".to_string()));
+    assert_eq!(c2.name_by_uuid_str(&uuid1s), Some("client1".to_string()));
+
+    assert_eq!(c1.name_by_uuid(uuid2), Some("client2".to_string()));
+    assert_eq!(c2.name_by_uuid(uuid2), Some("client2".to_string()));
+    assert_eq!(c1.name_by_uuid_str(&uuid2s), Some("client2".to_string()));
+    assert_eq!(c2.name_by_uuid_str(&uuid2s), Some("client2".to_string()));
+
+    //create and then dealloc a client, get the uuid.
+    let uuid3 = {
+        let (c3, _) = open_test_client("client3");
+        c3.uuid()
+    };
+    assert_eq!(c1.name_by_uuid(uuid3), None);
+    assert_eq!(c2.name_by_uuid(uuid3), None);
+}

--- a/src/client/test.rs
+++ b/src/client/test.rs
@@ -157,8 +157,51 @@ fn client_can_use_ringbuffer() {
 
 #[test]
 fn client_uuid() {
-    let (c1, _) = open_test_client("client1");
-    let (c2, _) = open_test_client("client2");
+    let (c1, _) = open_test_client("uuidtest-client1");
+    let (c2, _) = open_test_client("uuidtest-client2");
+
+    let uuid1s = c1.uuid_string();
+    let uuid2s = c2.uuid_string();
+    assert_ne!(uuid1s, uuid2s);
+
+    assert_eq!(
+        c1.name_by_uuid_str(&uuid1s),
+        Some("uuidtest-client1".to_string())
+    );
+    assert_eq!(
+        c2.name_by_uuid_str(&uuid1s),
+        Some("uuidtest-client1".to_string())
+    );
+
+    assert_eq!(
+        c1.name_by_uuid_str(&uuid2s),
+        Some("uuidtest-client2".to_string())
+    );
+    assert_eq!(
+        c2.name_by_uuid_str(&uuid2s),
+        Some("uuidtest-client2".to_string())
+    );
+
+    //create and then dealloc a client, get the uuid.
+    let uuid3s = {
+        let (c3, _) = open_test_client("uuidtest-client3");
+        c3.uuid_string()
+    };
+    assert_eq!(c1.name_by_uuid_str(&uuid3s), None);
+    assert_eq!(c2.name_by_uuid_str(&uuid3s), None);
+}
+
+#[cfg(feature = "metadata")]
+#[test]
+fn client_numeric_uuid() {
+    let (c1, _) = open_test_client("numeric-uuid-client1");
+    let (c2, _) = open_test_client("numeric-uuid-client2");
+
+    let ac1 = c1.activate_async((), ()).unwrap();
+    let ac2 = c2.activate_async((), ()).unwrap();
+
+    let c1 = ac1.as_client();
+    let c2 = ac2.as_client();
 
     let uuid1 = c1.uuid();
     let uuid2 = c2.uuid();
@@ -173,19 +216,43 @@ fn client_uuid() {
     assert_eq!(c1.name_by_uuid(0), None);
     assert_eq!(c2.name_by_uuid(0), None);
 
-    assert_eq!(c1.name_by_uuid(uuid1), Some("client1".to_string()));
-    assert_eq!(c2.name_by_uuid(uuid1), Some("client1".to_string()));
-    assert_eq!(c1.name_by_uuid_str(&uuid1s), Some("client1".to_string()));
-    assert_eq!(c2.name_by_uuid_str(&uuid1s), Some("client1".to_string()));
+    assert_eq!(
+        c1.name_by_uuid(uuid1),
+        Some("numeric-uuid-client1".to_string())
+    );
+    assert_eq!(
+        c2.name_by_uuid(uuid1),
+        Some("numeric-uuid-client1".to_string())
+    );
+    assert_eq!(
+        c1.name_by_uuid_str(&uuid1s),
+        Some("numeric-uuid-client1".to_string())
+    );
+    assert_eq!(
+        c2.name_by_uuid_str(&uuid1s),
+        Some("numeric-uuid-client1".to_string())
+    );
 
-    assert_eq!(c1.name_by_uuid(uuid2), Some("client2".to_string()));
-    assert_eq!(c2.name_by_uuid(uuid2), Some("client2".to_string()));
-    assert_eq!(c1.name_by_uuid_str(&uuid2s), Some("client2".to_string()));
-    assert_eq!(c2.name_by_uuid_str(&uuid2s), Some("client2".to_string()));
+    assert_eq!(
+        c1.name_by_uuid(uuid2),
+        Some("numeric-uuid-client2".to_string())
+    );
+    assert_eq!(
+        c2.name_by_uuid(uuid2),
+        Some("numeric-uuid-client2".to_string())
+    );
+    assert_eq!(
+        c1.name_by_uuid_str(&uuid2s),
+        Some("numeric-uuid-client2".to_string())
+    );
+    assert_eq!(
+        c2.name_by_uuid_str(&uuid2s),
+        Some("numeric-uuid-client2".to_string())
+    );
 
     //create and then dealloc a client, get the uuid.
     let uuid3 = {
-        let (c3, _) = open_test_client("client3");
+        let (c3, _) = open_test_client("numeric-uuid-client3");
         c3.uuid()
     };
     assert_eq!(c1.name_by_uuid(uuid3), None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,7 @@ pub fn get_time() -> primitive_types::Time {
     unsafe { jack_sys::jack_get_time() }
 }
 
+/// Get a `String` representation of the version of the Jack system that is in use.
 pub fn jack_version_string() -> String {
     unsafe {
         let s = jack_sys::jack_get_version_string();
@@ -99,7 +100,7 @@ pub fn jack_version_string() -> String {
     }
 }
 
-/// Get the version of the running jack system. Major, Minor, Patch
+/// Get the version of the Jack system that is in use. Major, Minor, Patch
 pub fn jack_version() -> Vec<isize> {
     //note, jack_get_version was returning all zeros
     let ver: Vec<isize> = jack_version_string()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,34 +89,6 @@ pub fn get_time() -> primitive_types::Time {
     unsafe { jack_sys::jack_get_time() }
 }
 
-/// Get a `String` representation of the version of the Jack system that is in use.
-pub fn jack_version_string() -> String {
-    unsafe {
-        let s = jack_sys::jack_get_version_string();
-        std::ffi::CStr::from_ptr(s)
-            .to_str()
-            .expect("version string to convert to str")
-            .to_string()
-    }
-}
-
-/// Get the version of the Jack system that is in use. Major, Minor, Patch
-pub fn jack_version() -> Vec<isize> {
-    //note, jack_get_version was returning all zeros
-    let ver: Vec<isize> = jack_version_string()
-        .split(".")
-        .map(|v| v.parse::<isize>().unwrap())
-        .collect();
-    assert!(ver.len() >= 3);
-    ver
-}
-
-/// See if the running jack system supports metadata (version 1.9.13+).
-pub fn jack_supports_metadata() -> bool {
-    let v = jack_version();
-    return v[0] > 1 || v[0] == 1 && v[1] > 9 || v[0] == 1 && v[1] == 9 && v[2] > 12;
-}
-
 #[cfg(test)]
 mod test {
     use super::*;
@@ -133,17 +105,5 @@ mod test {
         thread::sleep(time::Duration::from_millis(100));
         let later_t = get_time();
         assert!(initial_t < later_t, "failed {} < {}", initial_t, later_t);
-    }
-
-    #[test]
-    fn can_get_version() {
-        let v = jack_version();
-        assert!(v.len() >= 3);
-        assert!(v[0] >= 1);
-    }
-
-    #[test]
-    fn can_query_metadata_support() {
-        let _s = jack_supports_metadata();
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,6 +53,8 @@ pub use crate::transport::{
     TransportStatePosition,
 };
 
+pub use crate::properties::*;
+
 /// Create and manage client connections to a JACK server.
 mod client;
 
@@ -77,7 +79,7 @@ mod primitive_types;
 mod transport;
 
 /// Properties
-pub mod properties;
+mod properties;
 
 /// Return JACK's current system time in microseconds, using the JACK clock
 /// source.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,9 @@ mod primitive_types;
 /// Transport.
 mod transport;
 
+/// Properties
+pub mod properties;
+
 /// Return JACK's current system time in microseconds, using the JACK clock
 /// source.
 pub fn get_time() -> primitive_types::Time {

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -1,32 +1,7 @@
 //! Properties, AKA [Meta Data](https://jackaudio.org/api/group__Metadata.html)
 //!
-
-use crate::Error;
-use std::{collections::HashMap, ffi, mem::MaybeUninit, ptr};
-
-use crate::Client;
 use j::jack_uuid_t as uuid;
 use jack_sys as j;
-
-pub(crate) unsafe extern "C" fn property_changed<P>(
-    subject: j::jack_uuid_t,
-    key: *const ::libc::c_char,
-    change: j::jack_property_change_t,
-    arg: *mut ::libc::c_void,
-) -> ()
-where
-    P: PropertyChangeHandler,
-{
-    let h: &mut P = std::mem::transmute::<*mut ::libc::c_void, &mut P>(arg);
-    let key_c = ffi::CStr::from_ptr(key);
-    let key = key_c.to_str().expect("to convert key to valid str");
-    let c = match change {
-        j::PropertyCreated => PropertyChange::Created { subject, key },
-        j::PropertyDeleted => PropertyChange::Deleted { subject, key },
-        _ => PropertyChange::Changed { subject, key },
-    };
-    h.property_changed(&c);
-}
 
 /// A description of a Metadata change describint a creation, change or deletion, its owner
 /// `subject` and `key`.
@@ -37,502 +12,557 @@ pub enum PropertyChange<'a> {
     Deleted { subject: uuid, key: &'a str },
 }
 
-/// A helper enum, allowing for sending changes between threads.
-#[derive(Debug, Clone, PartialEq)]
-pub enum PropertyChangeOwned {
-    Created { subject: uuid, key: String },
-    Changed { subject: uuid, key: String },
-    Deleted { subject: uuid, key: String },
-}
-
+/// A trait for reacting to property changes.
+///
+/// # Remarks
+///
+/// * Only used if the `metadata` feature is enabled.
 pub trait PropertyChangeHandler: Send {
     fn property_changed(&mut self, change: &PropertyChange);
 }
 
-/// A piece of Metadata on a Jack `subject`: either a port or a client.
-/// See the JACK Metadata API [description](https://jackaudio.org/metadata/) and [documentation](https://jackaudio.org/api/group__Metadata.html) and for more info.
-#[derive(Debug, Clone, PartialEq)]
-pub struct Property {
-    value: String,
-    typ: Option<String>,
-}
-
-/// A map of Metadata `key`s, URI Strings, to `Property`s, value and optional type Strings, for a given subject.
-pub type PropertyMap = HashMap<String, Property>;
-
-/// Wrap a closure that chan handle a `property_changed` callback.
-/// This is called for every property that changes.
-pub struct ClosurePropertyChangeHandler<F>
+#[allow(dead_code)] //dead if we haven't enabled metadata
+pub(crate) unsafe extern "C" fn property_changed<P>(
+    subject: j::jack_uuid_t,
+    key: *const ::libc::c_char,
+    change: j::jack_property_change_t,
+    arg: *mut ::libc::c_void,
+) -> ()
 where
-    F: 'static + Send + FnMut(&PropertyChange),
+    P: PropertyChangeHandler,
 {
-    func: F,
+    let h: &mut P = std::mem::transmute::<*mut ::libc::c_void, &mut P>(arg);
+    let key_c = std::ffi::CStr::from_ptr(key);
+    let key = key_c.to_str().expect("to convert key to valid str");
+    let c = match change {
+        j::PropertyCreated => PropertyChange::Created { subject, key },
+        j::PropertyDeleted => PropertyChange::Deleted { subject, key },
+        _ => PropertyChange::Changed { subject, key },
+    };
+    h.property_changed(&c);
 }
 
-impl<F> ClosurePropertyChangeHandler<F>
-where
-    F: 'static + Send + FnMut(&PropertyChange),
-{
-    /// Create a new `PropertyChangeHandler` from a closure.
-    pub fn new(func: F) -> ClosurePropertyChangeHandler<F> {
-        ClosurePropertyChangeHandler { func }
+#[cfg(feature = "metadata")]
+pub use metadata::*;
+
+#[cfg(feature = "metadata")]
+mod metadata {
+    use super::*;
+    use crate::Error;
+    use std::{collections::HashMap, ffi, mem::MaybeUninit, ptr};
+
+    use crate::Client;
+
+    /// A helper enum, allowing for sending changes between threads.
+    #[derive(Debug, Clone, PartialEq)]
+    pub enum PropertyChangeOwned {
+        Created { subject: uuid, key: String },
+        Changed { subject: uuid, key: String },
+        Deleted { subject: uuid, key: String },
     }
-}
 
-impl<F> PropertyChangeHandler for ClosurePropertyChangeHandler<F>
-where
-    F: 'static + Send + FnMut(&PropertyChange),
-{
-    fn property_changed(&mut self, change: &PropertyChange) {
-        (self.func)(change)
+    /// A piece of Metadata on a Jack `subject`: either a port or a client.
+    /// See the JACK Metadata API [description](https://jackaudio.org/metadata/) and [documentation](https://jackaudio.org/api/group__Metadata.html) and for more info.
+    #[derive(Debug, Clone, PartialEq)]
+    pub struct Property {
+        value: String,
+        typ: Option<String>,
     }
-}
 
-//helper to map 0 return to Ok
-fn map_error<F: FnOnce() -> ::libc::c_int>(func: F) -> Result<(), Error> {
-    if func() == 0 {
-        Ok(())
-    } else {
-        Err(Error::UnknownError)
+    /// A map of Metadata `key`s, URI Strings, to `Property`s, value and optional type Strings, for a given subject.
+    pub type PropertyMap = HashMap<String, Property>;
+
+    /// Wrap a closure that chan handle a `property_changed` callback.
+    /// This is called for every property that changes.
+    pub struct ClosurePropertyChangeHandler<F>
+    where
+        F: 'static + Send + FnMut(&PropertyChange),
+    {
+        func: F,
     }
-}
 
-//helper to convert to an Option<PropertyMap> and free
-unsafe fn description_to_map_free(description: *mut j::jack_description_t) -> Option<PropertyMap> {
-    if description.is_null() {
-        None
-    } else {
-        let des = &*description;
-        let mut properties = HashMap::new();
-        for prop in std::slice::from_raw_parts(des.properties, des.property_cnt as usize) {
-            let typ = if prop._type.is_null() {
-                None
-            } else {
-                Some(
-                    ffi::CStr::from_ptr(prop._type)
+    impl<F> ClosurePropertyChangeHandler<F>
+    where
+        F: 'static + Send + FnMut(&PropertyChange),
+    {
+        /// Create a new `PropertyChangeHandler` from a closure.
+        pub fn new(func: F) -> ClosurePropertyChangeHandler<F> {
+            ClosurePropertyChangeHandler { func }
+        }
+    }
+
+    impl<F> PropertyChangeHandler for ClosurePropertyChangeHandler<F>
+    where
+        F: 'static + Send + FnMut(&PropertyChange),
+    {
+        fn property_changed(&mut self, change: &PropertyChange) {
+            (self.func)(change)
+        }
+    }
+
+    //helper to map 0 return to Ok
+    fn map_error<F: FnOnce() -> ::libc::c_int>(func: F) -> Result<(), Error> {
+        if func() == 0 {
+            Ok(())
+        } else {
+            Err(Error::UnknownError)
+        }
+    }
+
+    //helper to convert to an Option<PropertyMap> and free
+    unsafe fn description_to_map_free(
+        description: *mut j::jack_description_t,
+    ) -> Option<PropertyMap> {
+        if description.is_null() {
+            None
+        } else {
+            let des = &*description;
+            let mut properties = HashMap::new();
+            for prop in std::slice::from_raw_parts(des.properties, des.property_cnt as usize) {
+                let typ = if prop._type.is_null() {
+                    None
+                } else {
+                    Some(
+                        ffi::CStr::from_ptr(prop._type)
+                            .to_str()
+                            .expect("to convert type to str")
+                            .to_string(),
+                    )
+                };
+                properties.insert(
+                    ffi::CStr::from_ptr(prop.key)
                         .to_str()
-                        .expect("to convert type to str")
+                        .expect("to turn key to str")
                         .to_string(),
-                )
-            };
-            properties.insert(
-                ffi::CStr::from_ptr(prop.key)
-                    .to_str()
-                    .expect("to turn key to str")
-                    .to_string(),
-                Property::new(
-                    ffi::CStr::from_ptr(prop.data)
-                        .to_str()
-                        .expect("to turn data to str"),
-                    typ,
-                ),
+                    Property::new(
+                        ffi::CStr::from_ptr(prop.data)
+                            .to_str()
+                            .expect("to turn data to str"),
+                        typ,
+                    ),
+                );
+            }
+            j::jack_free_description(description, 0);
+            Some(properties)
+        }
+    }
+
+    impl Property {
+        /// Create a property.
+        ///
+        /// # Arguments
+        ///
+        /// * `value` - The value of the property.
+        /// * `typ` - The optional type of the property. Either a MIME type or URI.
+        pub fn new<V: ToString>(value: V, typ: Option<String>) -> Self {
+            Self {
+                value: value.to_string(),
+                typ,
+            }
+        }
+
+        /// Get the "value" of a property.
+        pub fn value(&self) -> &str {
+            &self.value
+        }
+
+        /// Get the "type" of a property, if it has been set.
+        /// Either a MIME type or URI.
+        pub fn typ(&self) -> Option<&str> {
+            self.typ.as_ref().map(|t| t.as_str())
+        }
+    }
+
+    #[cfg(feature = "metadata")]
+    impl Client {
+        /// Get a property from a subject.
+        ///
+        /// # Arguments
+        ///
+        /// * `subject` - The subject of the property.
+        /// * `key` - The key of the property, a URI String.
+        pub fn property_get(&self, subject: uuid, key: &str) -> Option<Property> {
+            let key = ffi::CString::new(key).expect("key to be convert to CString");
+            let mut value: MaybeUninit<*mut ::libc::c_char> = MaybeUninit::uninit();
+            let mut typ: MaybeUninit<*mut ::libc::c_char> = MaybeUninit::uninit();
+
+            unsafe {
+                if j::jack_get_property(subject, key.as_ptr(), value.as_mut_ptr(), typ.as_mut_ptr())
+                    == 0
+                {
+                    let value = value.assume_init();
+                    let typ = typ.assume_init();
+                    let r = Some(Property::new(
+                        ffi::CStr::from_ptr(value).to_str().unwrap(),
+                        if typ.is_null() {
+                            None
+                        } else {
+                            Some(ffi::CStr::from_ptr(typ).to_str().unwrap().to_string())
+                        },
+                    ));
+                    j::jack_free(value as _);
+                    if !typ.is_null() {
+                        j::jack_free(typ as _)
+                    }
+                    r
+                } else {
+                    None
+                }
+            }
+        }
+
+        /// Get all the properties from a subject.
+        ///
+        /// # Arguments
+        ///
+        /// * `subject` - The subject of the properties.
+        ///
+        /// # Remarks
+        ///
+        /// * The Jack API calls this data a 'description'.
+        pub fn property_get_subject(&self, subject: uuid) -> Option<PropertyMap> {
+            let mut description: MaybeUninit<j::jack_description_t> = MaybeUninit::uninit();
+            unsafe {
+                let _ = j::jack_get_properties(subject, description.as_mut_ptr());
+                description_to_map_free(description.as_mut_ptr())
+            }
+        }
+
+        /// Get all the properties from all the subjects with Metadata.
+        ///
+        /// # Remarks
+        ///
+        /// * The Jack API calls these maps 'descriptions'.
+        pub fn property_get_all(&self) -> HashMap<uuid, PropertyMap> {
+            let mut map = HashMap::new();
+            let mut descriptions: MaybeUninit<*mut j::jack_description_t> = MaybeUninit::uninit();
+            unsafe {
+                let cnt = j::jack_get_all_properties(descriptions.as_mut_ptr());
+                if cnt > 0 {
+                    let descriptions = descriptions.assume_init();
+                    for des in std::slice::from_raw_parts_mut(descriptions, cnt as usize) {
+                        let uuid = (*des).subject;
+                        if let Some(dmap) = description_to_map_free(des) {
+                            map.insert(uuid, dmap);
+                        }
+                    }
+                    j::jack_free(descriptions as _);
+                }
+            }
+            map
+        }
+
+        /// Set a property.
+        ///
+        /// # Arguments
+        ///
+        /// * `subject` - The subject of the property.
+        /// * `key` - The key of the property. A URI string.
+        pub fn property_set(
+            &self,
+            subject: uuid,
+            key: &str,
+            property: &Property,
+        ) -> Result<(), Error> {
+            let key = ffi::CString::new(key).expect("to create cstring from key");
+            let value =
+                ffi::CString::new(property.value.as_str()).expect("to create cstring from value");
+            map_error(|| unsafe {
+                if let Some(t) = property.typ() {
+                    let t = ffi::CString::new(t).unwrap();
+                    j::jack_set_property(
+                        self.raw(),
+                        subject,
+                        key.as_ptr(),
+                        value.as_ptr(),
+                        t.as_ptr(),
+                    )
+                } else {
+                    j::jack_set_property(
+                        self.raw(),
+                        subject,
+                        key.as_ptr(),
+                        value.as_ptr(),
+                        ptr::null(),
+                    )
+                }
+            })
+        }
+
+        /// Remove a single property from a subject.
+        ///
+        /// # Arguments
+        ///
+        /// * `subject` - The subject to remove all properties from.
+        /// * `key` - The key of the property to be removed. A URI string.
+        pub fn property_remove(&self, subject: uuid, key: &str) -> Result<(), Error> {
+            let key = ffi::CString::new(key).expect("to create cstring from key");
+            map_error(|| unsafe { j::jack_remove_property(self.raw(), subject, key.as_ptr()) })
+        }
+
+        /// Remove all properties from a subject.
+        ///
+        /// # Arguments
+        ///
+        /// * `subject` - The subject to remove all properties from.
+        pub fn property_remove_subject(&self, subject: uuid) -> Result<(), Error> {
+            unsafe {
+                if j::jack_remove_properties(self.raw(), subject) == -1 {
+                    Err(Error::UnknownError)
+                } else {
+                    Ok(())
+                }
+            }
+        }
+
+        /// Remove all properties.
+        ///
+        /// # Remarks
+        ///
+        /// * **WARNING!!** This deletes all Metadata managed by a running JACK server.
+        pub fn property_remove_all(&self) -> Result<(), Error> {
+            map_error(|| unsafe { j::jack_remove_all_properties(self.raw()) })
+        }
+    }
+
+    impl<'a> From<&PropertyChange<'a>> for PropertyChangeOwned {
+        fn from(foo: &PropertyChange<'a>) -> Self {
+            match foo {
+                &PropertyChange::Created { subject, key } => Self::Created {
+                    subject,
+                    key: key.into(),
+                },
+                &PropertyChange::Changed { subject, key } => Self::Changed {
+                    subject,
+                    key: key.into(),
+                },
+                &PropertyChange::Deleted { subject, key } => Self::Deleted {
+                    subject,
+                    key: key.into(),
+                },
+            }
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::client::*;
+        use std::sync::mpsc::{channel, Sender};
+
+        #[test]
+        fn supports_metadata() {
+            assert!(crate::jack_supports_metadata());
+        }
+
+        #[test]
+        fn can_set_and_get() {
+            let (c, _) = Client::new("dummy", ClientOptions::NO_START_SERVER).unwrap();
+
+            let prop1 = Property::new(&"foo", None);
+            assert_eq!(c.property_set(c.uuid(), &"blah", &prop1), Ok(()));
+
+            let prop2 = Property::new(
+                &"http://churchofrobotron.com/2084",
+                Some("robot apocalypse".into()),
+            );
+            assert_eq!(c.property_set(c.uuid(), &"mutant", &prop2), Ok(()));
+
+            assert_eq!(None, c.property_get(c.uuid(), "soda"));
+            assert_eq!(Some(prop1.clone()), c.property_get(c.uuid(), "blah"));
+            assert_eq!(Some(prop2.clone()), c.property_get(c.uuid(), "mutant"));
+
+            //get subject
+            let sub = c.property_get_subject(c.uuid());
+            assert!(sub.is_some());
+            let sub = sub.unwrap();
+            assert_eq!(2, sub.len());
+
+            assert_eq!(sub.get(&"blah".to_string()), Some(&prop1));
+            assert_eq!(sub.get(&"mutant".to_string()), Some(&prop2));
+            assert_eq!(sub.get(&"asdf".to_string()), None);
+
+            //get all
+            let all = c.property_get_all();
+            assert_ne!(0, all.len());
+
+            let sub = all.get(&c.uuid());
+            assert!(sub.is_some());
+            let sub = sub.unwrap();
+            assert_eq!(2, sub.len());
+
+            assert_eq!(sub.get(&"blah".to_string()), Some(&prop1));
+            assert_eq!(sub.get(&"mutant".to_string()), Some(&prop2));
+            assert_eq!(sub.get(&"asdf".to_string()), None);
+        }
+
+        #[test]
+        fn can_remove() {
+            let (c1, _) = Client::new("client1", ClientOptions::NO_START_SERVER).unwrap();
+            let (c2, _) = Client::new("client2", ClientOptions::NO_START_SERVER).unwrap();
+            let prop1 = Property::new(&"foo", None);
+            let prop2 = Property::new(
+                &"http://churchofrobotron.com/2084",
+                Some("robot apocalypse".into()),
+            );
+
+            assert_eq!(c1.property_set(c1.uuid(), &"blah", &prop1), Ok(()));
+            assert_eq!(c1.property_set(c2.uuid(), &"blah", &prop1), Ok(()));
+            assert_eq!(c2.property_set(c1.uuid(), &"mutant", &prop2), Ok(()));
+            assert_eq!(c2.property_set(c2.uuid(), &"mutant", &prop2), Ok(()));
+
+            assert_eq!(Some(prop1.clone()), c1.property_get(c1.uuid(), "blah"));
+            assert_eq!(Some(prop1.clone()), c1.property_get(c2.uuid(), "blah"));
+            assert_eq!(Some(prop2.clone()), c1.property_get(c1.uuid(), "mutant"));
+            assert_eq!(Some(prop2.clone()), c1.property_get(c2.uuid(), "mutant"));
+
+            assert_eq!(Ok(()), c1.property_remove(c1.uuid(), &"blah"));
+            assert_eq!(None, c1.property_get(c1.uuid(), "blah"));
+
+            //with other client
+            assert_eq!(Ok(()), c2.property_remove(c1.uuid(), &"mutant"));
+            assert_eq!(None, c1.property_get(c1.uuid(), "mutant"));
+
+            //second time, error
+            assert_eq!(
+                Err(Error::UnknownError),
+                c2.property_remove(c1.uuid(), &"mutant")
+            );
+
+            assert_eq!(Some(prop1.clone()), c2.property_get(c2.uuid(), "blah"));
+            assert_eq!(Some(prop2.clone()), c2.property_get(c2.uuid(), "mutant"));
+
+            assert_eq!(Ok(()), c1.property_remove_subject(c2.uuid()));
+            assert_eq!(None, c2.property_get(c2.uuid(), "blah"));
+            assert_eq!(None, c2.property_get(c2.uuid(), "mutant"));
+
+            //second time, okay
+            assert_eq!(Ok(()), c1.property_remove_subject(c2.uuid()));
+            assert_eq!(Ok(()), c2.property_remove_subject(c2.uuid()));
+            assert_eq!(None, c2.property_get(c2.uuid(), "blah"));
+            assert_eq!(None, c2.property_get(c2.uuid(), "mutant"));
+
+            assert_eq!(Ok(()), c2.property_remove_subject(c1.uuid()));
+            assert_eq!(Ok(()), c1.property_remove_subject(c1.uuid()));
+        }
+
+        #[test]
+        fn can_property_remove_all() {
+            let (c, _) = Client::new("dummy", ClientOptions::NO_START_SERVER).unwrap();
+            let prop = Property::new(&"foo", Some("bar".into()));
+            assert_eq!(c.property_set(c.uuid(), &"blah", &prop), Ok(()));
+
+            let sub = c.property_get_subject(c.uuid());
+            assert!(sub.is_some());
+            let sub = sub.unwrap();
+            assert_eq!(1, sub.len());
+
+            let all = c.property_get_all();
+            assert_ne!(0, all.len());
+
+            assert_eq!(c.property_remove_all(), Ok(()));
+            assert_eq!(None, c.property_get(c.uuid(), "blah"));
+
+            let sub = c.property_get_subject(c.uuid());
+            assert!(sub.is_some());
+            let sub = sub.unwrap();
+            assert_eq!(0, sub.len());
+
+            let all = c.property_get_all();
+            assert_eq!(0, all.len());
+        }
+
+        #[test]
+        fn client_callbacks() {
+            let timeout = std::time::Duration::from_millis(1);
+            let prop1 = Property::new(&"foo", None);
+            let prop2 = Property::new(
+                &"http://churchofrobotron.com/2084",
+                Some("robot apocalypse".into()),
+            );
+
+            let (mut c1, _) = Client::new("client1", ClientOptions::NO_START_SERVER).unwrap();
+            let (c2, _) = Client::new("client2", ClientOptions::NO_START_SERVER).unwrap();
+            let (sender, receiver): (Sender<PropertyChangeOwned>, _) = channel();
+            assert_eq!(
+                Ok(()),
+                c1.register_property_change_handler(ClosurePropertyChangeHandler::new(
+                    move |change| {
+                        assert_eq!(Ok(()), sender.send(change.into()));
+                    }
+                ))
+            );
+
+            //must activate to get callbacks
+            let ac = c1.activate_async((), ()).unwrap();
+
+            assert_eq!(c2.property_set(c2.uuid(), &"blah", &prop1), Ok(()));
+            let r = receiver.recv_timeout(timeout);
+            assert_eq!(
+                Ok(PropertyChangeOwned::Created {
+                    subject: c2.uuid(),
+                    key: "blah".into()
+                }),
+                r
+            );
+
+            //doesn't matter which client is used to set or remove the property
+            assert_eq!(
+                ac.as_client().property_set(c2.uuid(), &"blah", &prop2),
+                Ok(())
+            );
+            let r = receiver.recv_timeout(timeout);
+            assert_eq!(
+                Ok(PropertyChangeOwned::Changed {
+                    subject: c2.uuid(),
+                    key: "blah".into()
+                }),
+                r
+            );
+
+            assert_eq!(c2.property_remove(c2.uuid(), &"blah"), Ok(()));
+            let r = receiver.recv_timeout(timeout);
+            assert_eq!(
+                Ok(PropertyChangeOwned::Deleted {
+                    subject: c2.uuid(),
+                    key: "blah".into()
+                }),
+                r
+            );
+
+            assert_eq!(c2.property_set(c2.uuid(), &"blah", &prop1), Ok(()));
+            assert_eq!(
+                c2.property_set(ac.as_client().uuid(), &"mutant", &prop2),
+                Ok(())
+            );
+            let r = receiver.recv_timeout(timeout);
+            assert_eq!(
+                Ok(PropertyChangeOwned::Created {
+                    subject: c2.uuid(),
+                    key: "blah".into()
+                }),
+                r
+            );
+            let r = receiver.recv_timeout(timeout);
+            assert_eq!(
+                Ok(PropertyChangeOwned::Created {
+                    subject: ac.as_client().uuid(),
+                    key: "mutant".into()
+                }),
+                r
             );
         }
-        j::jack_free_description(description, 0);
-        Some(properties)
-    }
-}
 
-impl Property {
-    /// Create a property.
-    ///
-    /// # Arguments
-    ///
-    /// * `value` - The value of the property.
-    /// * `typ` - The optional type of the property. Either a MIME type or URI.
-    pub fn new<V: ToString>(value: V, typ: Option<String>) -> Self {
-        Self {
-            value: value.to_string(),
-            typ,
+        #[test]
+        #[should_panic]
+        fn double_register() {
+            let (mut c, _) = Client::new("client1", ClientOptions::NO_START_SERVER).unwrap();
+            assert_eq!(
+                Ok(()),
+                c.register_property_change_handler(ClosurePropertyChangeHandler::new(|_| {}))
+            );
+            let _panic =
+                c.register_property_change_handler(ClosurePropertyChangeHandler::new(|_| {}));
         }
-    }
-
-    /// Get the "value" of a property.
-    pub fn value(&self) -> &str {
-        &self.value
-    }
-
-    /// Get the "type" of a property, if it has been set.
-    /// Either a MIME type or URI.
-    pub fn typ(&self) -> Option<&str> {
-        self.typ.as_ref().map(|t| t.as_str())
-    }
-}
-
-impl Client {
-    /// Get a property from a subject.
-    ///
-    /// # Arguments
-    ///
-    /// * `subject` - The subject of the property.
-    /// * `key` - The key of the property, a URI String.
-    pub fn property_get(&self, subject: uuid, key: &str) -> Option<Property> {
-        let key = ffi::CString::new(key).expect("key to be convert to CString");
-        let mut value: MaybeUninit<*mut ::libc::c_char> = MaybeUninit::uninit();
-        let mut typ: MaybeUninit<*mut ::libc::c_char> = MaybeUninit::uninit();
-
-        unsafe {
-            if j::jack_get_property(subject, key.as_ptr(), value.as_mut_ptr(), typ.as_mut_ptr())
-                == 0
-            {
-                let value = value.assume_init();
-                let typ = typ.assume_init();
-                let r = Some(Property::new(
-                    ffi::CStr::from_ptr(value).to_str().unwrap(),
-                    if typ.is_null() {
-                        None
-                    } else {
-                        Some(ffi::CStr::from_ptr(typ).to_str().unwrap().to_string())
-                    },
-                ));
-                j::jack_free(value as _);
-                if !typ.is_null() {
-                    j::jack_free(typ as _)
-                }
-                r
-            } else {
-                None
-            }
-        }
-    }
-
-    /// Get all the properties from a subject.
-    ///
-    /// # Arguments
-    ///
-    /// * `subject` - The subject of the properties.
-    ///
-    /// # Remarks
-    ///
-    /// * The Jack API calls this data a 'description'.
-    pub fn property_get_subject(&self, subject: uuid) -> Option<PropertyMap> {
-        let mut description: MaybeUninit<j::jack_description_t> = MaybeUninit::uninit();
-        unsafe {
-            let _ = j::jack_get_properties(subject, description.as_mut_ptr());
-            description_to_map_free(description.as_mut_ptr())
-        }
-    }
-
-    /// Get all the properties from all the subjects with Metadata.
-    ///
-    /// # Remarks
-    ///
-    /// * The Jack API calls these maps 'descriptions'.
-    pub fn property_get_all(&self) -> HashMap<uuid, PropertyMap> {
-        let mut map = HashMap::new();
-        let mut descriptions: MaybeUninit<*mut j::jack_description_t> = MaybeUninit::uninit();
-        unsafe {
-            let cnt = j::jack_get_all_properties(descriptions.as_mut_ptr());
-            if cnt > 0 {
-                let descriptions = descriptions.assume_init();
-                for des in std::slice::from_raw_parts_mut(descriptions, cnt as usize) {
-                    let uuid = (*des).subject;
-                    if let Some(dmap) = description_to_map_free(des) {
-                        map.insert(uuid, dmap);
-                    }
-                }
-                j::jack_free(descriptions as _);
-            }
-        }
-        map
-    }
-
-    /// Set a property.
-    ///
-    /// # Arguments
-    ///
-    /// * `subject` - The subject of the property.
-    /// * `key` - The key of the property. A URI string.
-    pub fn property_set(&self, subject: uuid, key: &str, property: &Property) -> Result<(), Error> {
-        let key = ffi::CString::new(key).expect("to create cstring from key");
-        let value =
-            ffi::CString::new(property.value.as_str()).expect("to create cstring from value");
-        map_error(|| unsafe {
-            if let Some(t) = property.typ() {
-                let t = ffi::CString::new(t).unwrap();
-                j::jack_set_property(
-                    self.raw(),
-                    subject,
-                    key.as_ptr(),
-                    value.as_ptr(),
-                    t.as_ptr(),
-                )
-            } else {
-                j::jack_set_property(
-                    self.raw(),
-                    subject,
-                    key.as_ptr(),
-                    value.as_ptr(),
-                    ptr::null(),
-                )
-            }
-        })
-    }
-
-    /// Remove a single property from a subject.
-    ///
-    /// # Arguments
-    ///
-    /// * `subject` - The subject to remove all properties from.
-    /// * `key` - The key of the property to be removed. A URI string.
-    pub fn property_remove(&self, subject: uuid, key: &str) -> Result<(), Error> {
-        let key = ffi::CString::new(key).expect("to create cstring from key");
-        map_error(|| unsafe { j::jack_remove_property(self.raw(), subject, key.as_ptr()) })
-    }
-
-    /// Remove all properties from a subject.
-    ///
-    /// # Arguments
-    ///
-    /// * `subject` - The subject to remove all properties from.
-    pub fn property_remove_subject(&self, subject: uuid) -> Result<(), Error> {
-        unsafe {
-            if j::jack_remove_properties(self.raw(), subject) == -1 {
-                Err(Error::UnknownError)
-            } else {
-                Ok(())
-            }
-        }
-    }
-
-    /// Remove all properties.
-    ///
-    /// # Remarks
-    ///
-    /// * **WARNING!!** This deletes all Metadata managed by a running JACK server.
-    pub fn property_remove_all(&self) -> Result<(), Error> {
-        map_error(|| unsafe { j::jack_remove_all_properties(self.raw()) })
-    }
-}
-
-impl<'a> From<&PropertyChange<'a>> for PropertyChangeOwned {
-    fn from(foo: &PropertyChange<'a>) -> Self {
-        match foo {
-            &PropertyChange::Created { subject, key } => Self::Created {
-                subject,
-                key: key.into(),
-            },
-            &PropertyChange::Changed { subject, key } => Self::Changed {
-                subject,
-                key: key.into(),
-            },
-            &PropertyChange::Deleted { subject, key } => Self::Deleted {
-                subject,
-                key: key.into(),
-            },
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::client::*;
-    use std::sync::mpsc::{channel, Sender};
-
-    #[test]
-    fn can_set_and_get() {
-        let (c, _) = Client::new("dummy", ClientOptions::NO_START_SERVER).unwrap();
-
-        let prop1 = Property::new(&"foo", None);
-        assert_eq!(c.property_set(c.uuid(), &"blah", &prop1), Ok(()));
-
-        let prop2 = Property::new(
-            &"http://churchofrobotron.com/2084",
-            Some("robot apocalypse".into()),
-        );
-        assert_eq!(c.property_set(c.uuid(), &"mutant", &prop2), Ok(()));
-
-        assert_eq!(None, c.property_get(c.uuid(), "soda"));
-        assert_eq!(Some(prop1.clone()), c.property_get(c.uuid(), "blah"));
-        assert_eq!(Some(prop2.clone()), c.property_get(c.uuid(), "mutant"));
-
-        //get subject
-        let sub = c.property_get_subject(c.uuid());
-        assert!(sub.is_some());
-        let sub = sub.unwrap();
-        assert_eq!(2, sub.len());
-
-        assert_eq!(sub.get(&"blah".to_string()), Some(&prop1));
-        assert_eq!(sub.get(&"mutant".to_string()), Some(&prop2));
-        assert_eq!(sub.get(&"asdf".to_string()), None);
-
-        //get all
-        let all = c.property_get_all();
-        assert_ne!(0, all.len());
-
-        let sub = all.get(&c.uuid());
-        assert!(sub.is_some());
-        let sub = sub.unwrap();
-        assert_eq!(2, sub.len());
-
-        assert_eq!(sub.get(&"blah".to_string()), Some(&prop1));
-        assert_eq!(sub.get(&"mutant".to_string()), Some(&prop2));
-        assert_eq!(sub.get(&"asdf".to_string()), None);
-    }
-
-    #[test]
-    fn can_remove() {
-        let (c1, _) = Client::new("client1", ClientOptions::NO_START_SERVER).unwrap();
-        let (c2, _) = Client::new("client2", ClientOptions::NO_START_SERVER).unwrap();
-        let prop1 = Property::new(&"foo", None);
-        let prop2 = Property::new(
-            &"http://churchofrobotron.com/2084",
-            Some("robot apocalypse".into()),
-        );
-
-        assert_eq!(c1.property_set(c1.uuid(), &"blah", &prop1), Ok(()));
-        assert_eq!(c1.property_set(c2.uuid(), &"blah", &prop1), Ok(()));
-        assert_eq!(c2.property_set(c1.uuid(), &"mutant", &prop2), Ok(()));
-        assert_eq!(c2.property_set(c2.uuid(), &"mutant", &prop2), Ok(()));
-
-        assert_eq!(Some(prop1.clone()), c1.property_get(c1.uuid(), "blah"));
-        assert_eq!(Some(prop1.clone()), c1.property_get(c2.uuid(), "blah"));
-        assert_eq!(Some(prop2.clone()), c1.property_get(c1.uuid(), "mutant"));
-        assert_eq!(Some(prop2.clone()), c1.property_get(c2.uuid(), "mutant"));
-
-        assert_eq!(Ok(()), c1.property_remove(c1.uuid(), &"blah"));
-        assert_eq!(None, c1.property_get(c1.uuid(), "blah"));
-
-        //with other client
-        assert_eq!(Ok(()), c2.property_remove(c1.uuid(), &"mutant"));
-        assert_eq!(None, c1.property_get(c1.uuid(), "mutant"));
-
-        //second time, error
-        assert_eq!(
-            Err(Error::UnknownError),
-            c2.property_remove(c1.uuid(), &"mutant")
-        );
-
-        assert_eq!(Some(prop1.clone()), c2.property_get(c2.uuid(), "blah"));
-        assert_eq!(Some(prop2.clone()), c2.property_get(c2.uuid(), "mutant"));
-
-        assert_eq!(Ok(()), c1.property_remove_subject(c2.uuid()));
-        assert_eq!(None, c2.property_get(c2.uuid(), "blah"));
-        assert_eq!(None, c2.property_get(c2.uuid(), "mutant"));
-
-        //second time, okay
-        assert_eq!(Ok(()), c1.property_remove_subject(c2.uuid()));
-        assert_eq!(Ok(()), c2.property_remove_subject(c2.uuid()));
-        assert_eq!(None, c2.property_get(c2.uuid(), "blah"));
-        assert_eq!(None, c2.property_get(c2.uuid(), "mutant"));
-
-        assert_eq!(Ok(()), c2.property_remove_subject(c1.uuid()));
-        assert_eq!(Ok(()), c1.property_remove_subject(c1.uuid()));
-    }
-
-    #[test]
-    fn can_property_remove_all() {
-        let (c, _) = Client::new("dummy", ClientOptions::NO_START_SERVER).unwrap();
-        let prop = Property::new(&"foo", Some("bar".into()));
-        assert_eq!(c.property_set(c.uuid(), &"blah", &prop), Ok(()));
-
-        let sub = c.property_get_subject(c.uuid());
-        assert!(sub.is_some());
-        let sub = sub.unwrap();
-        assert_eq!(1, sub.len());
-
-        let all = c.property_get_all();
-        assert_ne!(0, all.len());
-
-        assert_eq!(c.property_remove_all(), Ok(()));
-        assert_eq!(None, c.property_get(c.uuid(), "blah"));
-
-        let sub = c.property_get_subject(c.uuid());
-        assert!(sub.is_some());
-        let sub = sub.unwrap();
-        assert_eq!(0, sub.len());
-
-        let all = c.property_get_all();
-        assert_eq!(0, all.len());
-    }
-
-    #[test]
-    fn client_callbacks() {
-        let timeout = std::time::Duration::from_millis(1);
-        let prop1 = Property::new(&"foo", None);
-        let prop2 = Property::new(
-            &"http://churchofrobotron.com/2084",
-            Some("robot apocalypse".into()),
-        );
-
-        let (mut c1, _) = Client::new("client1", ClientOptions::NO_START_SERVER).unwrap();
-        let (c2, _) = Client::new("client2", ClientOptions::NO_START_SERVER).unwrap();
-        let (sender, receiver): (Sender<PropertyChangeOwned>, _) = channel();
-        assert_eq!(
-            Ok(()),
-            c1.register_property_change_handler(ClosurePropertyChangeHandler::new(move |change| {
-                assert_eq!(Ok(()), sender.send(change.into()));
-            }))
-        );
-
-        //must activate to get callbacks
-        let ac = c1.activate_async((), ()).unwrap();
-
-        assert_eq!(c2.property_set(c2.uuid(), &"blah", &prop1), Ok(()));
-        let r = receiver.recv_timeout(timeout);
-        assert_eq!(
-            Ok(PropertyChangeOwned::Created {
-                subject: c2.uuid(),
-                key: "blah".into()
-            }),
-            r
-        );
-
-        //doesn't matter which client is used to set or remove the property
-        assert_eq!(
-            ac.as_client().property_set(c2.uuid(), &"blah", &prop2),
-            Ok(())
-        );
-        assert_eq!(c2.property_remove(c2.uuid(), &"blah"), Ok(()));
-        let r = receiver.recv_timeout(timeout);
-        assert_eq!(
-            Ok(PropertyChangeOwned::Changed {
-                subject: c2.uuid(),
-                key: "blah".into()
-            }),
-            r
-        );
-        let r = receiver.recv_timeout(timeout);
-        assert_eq!(
-            Ok(PropertyChangeOwned::Deleted {
-                subject: c2.uuid(),
-                key: "blah".into()
-            }),
-            r
-        );
-
-        assert_eq!(c2.property_set(c2.uuid(), &"blah", &prop1), Ok(()));
-        assert_eq!(
-            c2.property_set(ac.as_client().uuid(), &"mutant", &prop2),
-            Ok(())
-        );
-        let r = receiver.recv_timeout(timeout);
-        assert_eq!(
-            Ok(PropertyChangeOwned::Created {
-                subject: c2.uuid(),
-                key: "blah".into()
-            }),
-            r
-        );
-        let r = receiver.recv_timeout(timeout);
-        assert_eq!(
-            Ok(PropertyChangeOwned::Created {
-                subject: ac.as_client().uuid(),
-                key: "mutant".into()
-            }),
-            r
-        );
-    }
-
-    #[test]
-    #[should_panic]
-    fn double_register() {
-        let (mut c, _) = Client::new("client1", ClientOptions::NO_START_SERVER).unwrap();
-        assert_eq!(
-            Ok(()),
-            c.register_property_change_handler(ClosurePropertyChangeHandler::new(|_| {}))
-        );
-        let _panic = c.register_property_change_handler(ClosurePropertyChangeHandler::new(|_| {}));
     }
 }

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -351,11 +351,6 @@ mod metadata {
         use std::sync::mpsc::{channel, Sender};
 
         #[test]
-        fn supports_metadata() {
-            assert!(crate::jack_supports_metadata());
-        }
-
-        #[test]
         fn can_set_and_get() {
             let (c, _) = Client::new("dummy", ClientOptions::NO_START_SERVER).unwrap();
 

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -37,7 +37,7 @@ pub enum PropertyChange<'a> {
     Deleted { subject: uuid, key: &'a str },
 }
 
-/// A helper enum, allowing fro sending changes between threads.
+/// A helper enum, allowing for sending changes between threads.
 #[derive(Debug, Clone, PartialEq)]
 pub enum PropertyChangeOwned {
     Created { subject: uuid, key: String },

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -474,7 +474,7 @@ mod metadata {
 
         #[test]
         fn client_callbacks() {
-            let timeout = std::time::Duration::from_millis(1);
+            let timeout = std::time::Duration::from_millis(10);
             let prop1 = Property::new(&"foo", None);
             let prop2 = Property::new(
                 &"http://churchofrobotron.com/2084",


### PR DESCRIPTION
Mostly behind a feature flag since it isn't supported until 1.9.13.

Not all of the property methods actually require a client but it felt more ergonomic to have them be consistent and make them methods on a client.