### PR TITLE
Move buffer_size callback to ProcessHandler

### DIFF
--- a/examples/playback_capture.rs
+++ b/examples/playback_capture.rs
@@ -64,11 +64,6 @@ impl jack::NotificationHandler for Notifications {
         );
     }
 
-    fn buffer_size(&mut self, _: &jack::Client, sz: jack::Frames) -> jack::Control {
-        println!("JACK: buffer size changed to {}", sz);
-        jack::Control::Continue
-    }
-
     fn sample_rate(&mut self, _: &jack::Client, srate: jack::Frames) -> jack::Control {
         println!("JACK: sample rate changed to {}", srate);
         jack::Control::Continue

--- a/src/client/test_callback.rs
+++ b/src/client/test_callback.rs
@@ -27,11 +27,6 @@ impl NotificationHandler for Counter {
         self.thread_init_count.fetch_add(1, Ordering::Relaxed);
     }
 
-    fn buffer_size(&mut self, _: &Client, size: Frames) -> Control {
-        self.buffer_size_change_history.push(size);
-        Control::Continue
-    }
-
     fn client_registration(&mut self, _: &Client, name: &str, is_registered: bool) {
         if is_registered {
             self.registered_client_history.push(name.to_string())
@@ -63,6 +58,11 @@ impl ProcessHandler for Counter {
         if self.induce_xruns {
             thread::sleep(time::Duration::from_millis(400));
         }
+        Control::Continue
+    }
+
+    fn buffer_size(&mut self, _: &Client, size: Frames) -> Control {
+        self.buffer_size_change_history.push(size);
         Control::Continue
     }
 }

--- a/src/client/test_callback.rs
+++ b/src/client/test_callback.rs
@@ -131,14 +131,14 @@ fn client_cback_calls_process() {
 
 #[test]
 fn client_cback_calls_buffer_size() {
-    let ac = active_test_client("client_cback_calls_process");
+    let ac = active_test_client("client_cback_calls_buffer_size");
     let initial = ac.as_client().buffer_size();
     let second = initial / 2;
     let third = second / 2;
     ac.as_client().set_buffer_size(second).unwrap();
     ac.as_client().set_buffer_size(third).unwrap();
     ac.as_client().set_buffer_size(initial).unwrap();
-    let counter = ac.deactivate().unwrap().1;
+    let counter = ac.deactivate().unwrap().2;
     let mut history_iter = counter.buffer_size_change_history.iter().cloned();
     assert_eq!(history_iter.find(|&s| s == initial), Some(initial));
     assert_eq!(history_iter.find(|&s| s == second), Some(second));


### PR DESCRIPTION
Implements the change discussed in #137. I also added a test to check the assumption that `buffer_size` is called on the same thread as `process`.

This is a breaking change but I did not change the version yet.