### PR TITLE
jack-sys: search for jack library with pkg-config

### DIFF
--- a/jack-sys/Cargo.toml
+++ b/jack-sys/Cargo.toml
@@ -11,3 +11,6 @@ license = "MIT OR Apache-2.0"
 libc = "0.2"
 libloading = "0.6"
 lazy_static = "1.4"
+
+[build-dependencies]
+pkg-config = "0.3"

--- a/jack-sys/Cargo.toml
+++ b/jack-sys/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Patrick Reisert"]
 description = "Low-level binding to the JACK audio API."
 repository = "https://github.com/RustAudio/rust-jack/tree/main/jack-sys"
 license = "MIT OR Apache-2.0"
+links = "jack"
 
 [dependencies]
 libc = "0.2"

--- a/jack-sys/build.rs
+++ b/jack-sys/build.rs
@@ -1,0 +1,7 @@
+fn main() {
+    // pkg-config is required to find PipeWire's implementation of libjack
+    // Refer to https://github.com/RustAudio/rust-jack/issues/142 for details.
+    // Do not unwrap this because linking might still work if pkg-config is
+    // not installed, for example on Windows.
+    let _ = pkg_config::probe_library("jack");
+}


### PR DESCRIPTION
This fixes linking with PipeWire's JACK headers.
Fixes #142