### PR TITLE
Add dlib support for jack-sys.

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -24,5 +24,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D clippy::all
       - name: Build
         run: cargo build --verbose
-      - name: Run tests
+      - name: Run Tests
         run: RUST_TEST_THREADS=1 cargo test --verbose
+      - name: Internal Client Test
+        run: cargo run --example internal_client </dev/null

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,5 +26,3 @@ jobs:
         run: cargo build --verbose
       - name: Run Tests
         run: RUST_TEST_THREADS=1 cargo test --verbose
-      - name: Internal Client Test
-        run: cargo run --example internal_client </dev/null

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,8 @@ version = "0.8.4"
 
 [dependencies]
 bitflags = "1"
-jack-sys = {path = "./jack-sys", version = "0.2.3"}
+dlib = "0.5"
+jack-sys = {path = "./jack-sys"}
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"

--- a/jack-sys/Cargo.toml
+++ b/jack-sys/Cargo.toml
@@ -1,17 +1,22 @@
 [package]
-name = "jack-sys"
-version = "0.2.3"
-edition = "2018"
 authors = ["Patrick Reisert"]
 description = "Low-level binding to the JACK audio API."
-repository = "https://github.com/RustAudio/rust-jack/tree/main/jack-sys"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 links = "jack"
+name = "jack-sys"
+repository = "https://github.com/RustAudio/rust-jack/tree/main/jack-sys"
+version = "0.3.0"
 
 [dependencies]
-libc = "0.2"
-libloading = "0.6"
+dlib = "0.5"
+dlopen = {version = "0.1", optional = true}
 lazy_static = "1.4"
+libc = "0.2"
+libloading = "0.7"
 
 [build-dependencies]
 pkg-config = "0.3"
+
+[features]
+default = []

--- a/jack-sys/Cargo.toml
+++ b/jack-sys/Cargo.toml
@@ -19,4 +19,6 @@ libloading = "0.7"
 pkg-config = "0.3"
 
 [features]
+# If dlopen is set, then dlib must be used to call jack-sys functions.  See
+# https://github.com/vberger/dlib.
 default = []

--- a/jack-sys/src/lib.rs
+++ b/jack-sys/src/lib.rs
@@ -1,5 +1,6 @@
 #![allow(non_camel_case_types, non_upper_case_globals)]
 
+use dlib::external_library;
 use lazy_static::lazy_static;
 
 /// JACK port type for 8 bit raw midi
@@ -491,575 +492,575 @@ extern "C" {
         ::std::option::Option<unsafe extern "C" fn(msg: *const ::libc::c_char) -> ()>;
     pub static mut jack_info_callback:
         ::std::option::Option<unsafe extern "C" fn(msg: *const ::libc::c_char) -> ()>;
-    pub static mut JACK_METADATA_PRETTY_NAME: *const ::libc::c_char;
-    pub static mut JACK_METADATA_HARDWARE: *const ::libc::c_char;
-    pub static mut JACK_METADATA_CONNECTED: *const ::libc::c_char;
-    pub static mut JACK_METADATA_PORT_GROUP: *const ::libc::c_char;
-    pub static mut JACK_METADATA_ICON_SMALL: *const ::libc::c_char;
-    pub static mut JACK_METADATA_ICON_LARGE: *const ::libc::c_char;
 }
 
-#[cfg(not(target_os = "windows"))]
-#[link(name = "jack")]
-extern "C" {}
+external_library!(
+    JackMetadata,
+    "jack",
+    statics: JACK_METADATA_PRETTY_NAME: *const ::libc::c_char,
+    JACK_METADATA_HARDWARE: *const ::libc::c_char,
+    JACK_METADATA_CONNECTED: *const ::libc::c_char,
+    JACK_METADATA_PORT_GROUP: *const ::libc::c_char,
+    JACK_METADATA_ICON_SMALL: *const ::libc::c_char,
+    JACK_METADATA_ICON_LARGE: *const ::libc::c_char,
+);
 
-extern "C" {
-    pub fn jack_release_timebase(client: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_set_sync_callback(
-        client: *mut jack_client_t,
-        sync_callback: JackSyncCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_sync_timeout(client: *mut jack_client_t, timeout: jack_time_t)
-        -> ::libc::c_int;
-    pub fn jack_set_timebase_callback(
-        client: *mut jack_client_t,
-        conditional: ::libc::c_int,
-        timebase_callback: TimebaseCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_transport_locate(
-        client: *mut jack_client_t,
-        frame: jack_nframes_t,
-    ) -> ::libc::c_int;
-    pub fn jack_transport_query(
-        client: *const jack_client_t,
-        pos: *mut jack_position_t,
-    ) -> jack_transport_state_t;
-    pub fn jack_get_current_transport_frame(client: *const jack_client_t) -> jack_nframes_t;
-    pub fn jack_transport_reposition(
-        client: *mut jack_client_t,
-        pos: *const jack_position_t,
-    ) -> ::libc::c_int;
-    pub fn jack_transport_start(client: *mut jack_client_t) -> ();
-    pub fn jack_transport_stop(client: *mut jack_client_t) -> ();
-    pub fn jack_get_transport_info(
-        client: *mut jack_client_t,
-        tinfo: *mut jack_transport_info_t,
-    ) -> ();
-    pub fn jack_set_transport_info(
-        client: *mut jack_client_t,
-        tinfo: *mut jack_transport_info_t,
-    ) -> ();
-    pub fn jack_get_version(
-        major_ptr: *mut ::libc::c_int,
-        minor_ptr: *mut ::libc::c_int,
-        micro_ptr: *mut ::libc::c_int,
-        proto_ptr: *mut ::libc::c_int,
-    ) -> ();
-    pub fn jack_get_version_string() -> *const ::libc::c_char;
-    pub fn jack_client_open(
-        client_name: *const ::libc::c_char,
-        options: jack_options_t,
-        status: *mut jack_status_t,
-        ...
-    ) -> *mut jack_client_t;
-    pub fn jack_client_new(client_name: *const ::libc::c_char) -> *mut jack_client_t;
-    pub fn jack_client_close(client: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_client_name_size() -> ::libc::c_int;
-    pub fn jack_get_client_name(client: *mut jack_client_t) -> *mut ::libc::c_char;
-    pub fn jack_get_uuid_for_client_name(
-        client: *mut jack_client_t,
-        client_name: *const ::libc::c_char,
-    ) -> *mut ::libc::c_char;
-    pub fn jack_get_client_name_by_uuid(
-        client: *mut jack_client_t,
-        client_uuid: *const ::libc::c_char,
-    ) -> *mut ::libc::c_char;
-    pub fn jack_internal_client_new(
-        client_name: *const ::libc::c_char,
-        load_name: *const ::libc::c_char,
-        load_init: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_internal_client_close(client_name: *const ::libc::c_char) -> ();
-    pub fn jack_activate(client: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_deactivate(client: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_get_client_pid(name: *const ::libc::c_char) -> ::libc::c_int;
-    #[cfg(not(target_os = "windows"))]
-    pub fn jack_client_thread_id(client: *mut jack_client_t) -> jack_native_thread_t;
-    pub fn jack_is_realtime(client: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_thread_wait(client: *mut jack_client_t, status: ::libc::c_int) -> jack_nframes_t;
-    pub fn jack_cycle_wait(client: *mut jack_client_t) -> jack_nframes_t;
-    pub fn jack_cycle_signal(client: *mut jack_client_t, status: ::libc::c_int) -> ();
-    pub fn jack_set_process_thread(
-        client: *mut jack_client_t,
-        thread_callback: JackThreadCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_thread_init_callback(
-        client: *mut jack_client_t,
-        thread_init_callback: JackThreadInitCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_on_shutdown(
-        client: *mut jack_client_t,
-        shutdown_callback: JackShutdownCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ();
-    pub fn jack_on_info_shutdown(
-        client: *mut jack_client_t,
-        shutdown_callback: JackInfoShutdownCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ();
-    pub fn jack_set_process_callback(
-        client: *mut jack_client_t,
-        process_callback: JackProcessCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_freewheel_callback(
-        client: *mut jack_client_t,
-        freewheel_callback: JackFreewheelCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_buffer_size_callback(
-        client: *mut jack_client_t,
-        bufsize_callback: JackBufferSizeCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_sample_rate_callback(
-        client: *mut jack_client_t,
-        srate_callback: JackSampleRateCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_client_registration_callback(
-        client: *mut jack_client_t,
-        registration_callback: JackClientRegistrationCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_port_registration_callback(
-        client: *mut jack_client_t,
-        registration_callback: JackPortRegistrationCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_port_connect_callback(
-        client: *mut jack_client_t,
-        connect_callback: JackPortConnectCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_port_rename_callback(
-        client: *mut jack_client_t,
-        rename_callback: JackPortRenameCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_graph_order_callback(
-        client: *mut jack_client_t,
-        graph_callback: JackGraphOrderCallback,
-        arg1: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_xrun_callback(
-        client: *mut jack_client_t,
-        xrun_callback: JackXRunCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_latency_callback(
-        client: *mut jack_client_t,
-        latency_callback: JackLatencyCallback,
-        arg1: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_set_freewheel(client: *mut jack_client_t, onoff: ::libc::c_int) -> ::libc::c_int;
-    pub fn jack_set_buffer_size(
-        client: *mut jack_client_t,
-        nframes: jack_nframes_t,
-    ) -> ::libc::c_int;
-    pub fn jack_get_sample_rate(arg1: *mut jack_client_t) -> jack_nframes_t;
-    pub fn jack_get_buffer_size(arg1: *mut jack_client_t) -> jack_nframes_t;
-    pub fn jack_engine_takeover_timebase(arg1: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_cpu_load(client: *mut jack_client_t) -> ::libc::c_float;
-    pub fn jack_port_register(
-        client: *mut jack_client_t,
-        port_name: *const ::libc::c_char,
-        port_type: *const ::libc::c_char,
-        flags: ::libc::c_ulong,
-        buffer_size: ::libc::c_ulong,
-    ) -> *mut jack_port_t;
-    pub fn jack_port_unregister(
-        client: *mut jack_client_t,
-        port: *mut jack_port_t,
-    ) -> ::libc::c_int;
-    pub fn jack_port_get_buffer(
-        port: *mut jack_port_t,
-        arg1: jack_nframes_t,
-    ) -> *mut ::libc::c_void;
-    pub fn jack_port_uuid(port: *const jack_port_t) -> jack_uuid_t;
-    pub fn jack_port_name(port: *const jack_port_t) -> *const ::libc::c_char;
-    pub fn jack_port_short_name(port: *const jack_port_t) -> *const ::libc::c_char;
-    pub fn jack_port_flags(port: *const jack_port_t) -> ::libc::c_int;
-    pub fn jack_port_type(port: *const jack_port_t) -> *const ::libc::c_char;
-    pub fn jack_port_type_id(port: *const jack_port_t) -> jack_port_type_id_t;
-    pub fn jack_port_is_mine(
-        client: *const jack_client_t,
-        port: *const jack_port_t,
-    ) -> ::libc::c_int;
-    pub fn jack_port_connected(port: *const jack_port_t) -> ::libc::c_int;
-    pub fn jack_port_connected_to(
-        port: *const jack_port_t,
-        port_name: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_port_get_connections(port: *const jack_port_t) -> *mut *const ::libc::c_char;
-    pub fn jack_port_get_all_connections(
-        client: *const jack_client_t,
-        port: *const jack_port_t,
-    ) -> *mut *const ::libc::c_char;
-    pub fn jack_port_tie(src: *mut jack_port_t, dst: *mut jack_port_t) -> ::libc::c_int;
-    pub fn jack_port_untie(port: *mut jack_port_t) -> ::libc::c_int;
-    pub fn jack_port_set_name(
-        port: *mut jack_port_t,
-        port_name: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_port_set_alias(
-        port: *mut jack_port_t,
-        alias: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_port_unset_alias(
-        port: *mut jack_port_t,
-        alias: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_port_get_aliases(
-        port: *const jack_port_t,
-        aliases: *mut *mut ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_port_request_monitor(port: *mut jack_port_t, onoff: ::libc::c_int)
-        -> ::libc::c_int;
-    pub fn jack_port_request_monitor_by_name(
-        client: *mut jack_client_t,
-        port_name: *const ::libc::c_char,
-        onoff: ::libc::c_int,
-    ) -> ::libc::c_int;
-    pub fn jack_port_ensure_monitor(port: *mut jack_port_t, onoff: ::libc::c_int) -> ::libc::c_int;
-    pub fn jack_port_monitoring_input(port: *mut jack_port_t) -> ::libc::c_int;
-    pub fn jack_connect(
-        client: *mut jack_client_t,
-        source_port: *const ::libc::c_char,
-        destination_port: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_disconnect(
-        client: *mut jack_client_t,
-        source_port: *const ::libc::c_char,
-        destination_port: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_port_disconnect(
-        client: *mut jack_client_t,
-        port: *mut jack_port_t,
-    ) -> ::libc::c_int;
-    pub fn jack_port_name_size() -> ::libc::c_int;
-    pub fn jack_port_type_size() -> ::libc::c_int;
-    pub fn jack_port_type_get_buffer_size(
-        client: *mut jack_client_t,
-        port_type: *const ::libc::c_char,
-    ) -> ::libc::size_t;
-    pub fn jack_port_set_latency(port: *mut jack_port_t, arg1: jack_nframes_t) -> ();
-    pub fn jack_port_get_latency_range(
-        port: *mut jack_port_t,
-        mode: jack_latency_callback_mode_t,
-        range: *mut jack_latency_range_t,
-    ) -> ();
-    pub fn jack_port_set_latency_range(
-        port: *mut jack_port_t,
-        mode: jack_latency_callback_mode_t,
-        range: *mut jack_latency_range_t,
-    ) -> ();
-    pub fn jack_recompute_total_latencies(client: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_port_get_latency(port: *mut jack_port_t) -> jack_nframes_t;
-    pub fn jack_port_get_total_latency(
-        client: *mut jack_client_t,
-        port: *mut jack_port_t,
-    ) -> jack_nframes_t;
-    pub fn jack_recompute_total_latency(
-        arg1: *mut jack_client_t,
-        port: *mut jack_port_t,
-    ) -> ::libc::c_int;
-    pub fn jack_get_ports(
-        client: *mut jack_client_t,
-        port_name_pattern: *const ::libc::c_char,
-        type_name_pattern: *const ::libc::c_char,
-        flags: ::libc::c_ulong,
-    ) -> *mut *const ::libc::c_char;
-    pub fn jack_port_by_name(
-        client: *mut jack_client_t,
-        port_name: *const ::libc::c_char,
-    ) -> *mut jack_port_t;
-    pub fn jack_port_by_id(client: *mut jack_client_t, port_id: jack_port_id_t)
-        -> *mut jack_port_t;
-    pub fn jack_frames_since_cycle_start(arg1: *const jack_client_t) -> jack_nframes_t;
-    pub fn jack_frame_time(arg1: *const jack_client_t) -> jack_nframes_t;
-    pub fn jack_last_frame_time(client: *const jack_client_t) -> jack_nframes_t;
+external_library!(
+    JackLib,
+    "jack",
+        functions:
+            fn jack_release_timebase(*mut jack_client_t) -> ::libc::c_int,
+        fn jack_set_sync_callback(
+             *mut jack_client_t,
+             JackSyncCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_sync_timeout(*mut jack_client_t, jack_time_t)
+            -> ::libc::c_int,
+        fn jack_set_timebase_callback(
+            *mut jack_client_t,
+            ::libc::c_int,
+            TimebaseCallback,
+            *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_transport_locate(
+            *mut jack_client_t,
+            jack_nframes_t
+        ) -> ::libc::c_int,
+        fn jack_transport_query(
+            *const jack_client_t,
+            *mut jack_position_t
+        ) -> jack_transport_state_t,
+        fn jack_get_current_transport_frame(*const jack_client_t) -> jack_nframes_t,
+        fn jack_transport_reposition(
+             *mut jack_client_t,
+             *const jack_position_t
+        ) -> ::libc::c_int,
+        fn jack_transport_start( *mut jack_client_t) -> (),
+        fn jack_transport_stop( *mut jack_client_t) -> (),
+        fn jack_get_transport_info(
+             *mut jack_client_t,
+             *mut jack_transport_info_t
+        ) -> (),
+        fn jack_set_transport_info(
+             *mut jack_client_t,
+             *mut jack_transport_info_t
+        ) -> (),
+        fn jack_get_version(
+             *mut ::libc::c_int,
+             *mut ::libc::c_int,
+             *mut ::libc::c_int,
+             *mut ::libc::c_int
+        ) -> (),
+        fn jack_get_version_string() -> *const ::libc::c_char,
+        fn jack_client_new( *const ::libc::c_char) -> *mut jack_client_t,
+        fn jack_client_close( *mut jack_client_t) -> ::libc::c_int,
+        fn jack_client_name_size() -> ::libc::c_int,
+        fn jack_get_client_name( *mut jack_client_t) -> *mut ::libc::c_char,
+        fn jack_get_uuid_for_client_name(
+             *mut jack_client_t,
+             *const ::libc::c_char
+        ) -> *mut ::libc::c_char,
+        fn jack_get_client_name_by_uuid(
+             *mut jack_client_t,
+             *const ::libc::c_char
+        ) -> *mut ::libc::c_char,
+        fn jack_internal_client_new(
+             *const ::libc::c_char,
+             *const ::libc::c_char,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_internal_client_close( *const ::libc::c_char) -> (),
+        fn jack_activate( *mut jack_client_t) -> ::libc::c_int,
+        fn jack_deactivate( *mut jack_client_t) -> ::libc::c_int,
+        fn jack_get_client_pid( *const ::libc::c_char) -> ::libc::c_int,
+        // #[cfg(not(target_os = "windows"))]
+        // fn jack_client_thread_id( *mut jack_client_t) -> jack_native_thread_t,
+        fn jack_is_realtime( *mut jack_client_t) -> ::libc::c_int,
+        fn jack_thread_wait( *mut jack_client_t, ::libc::c_int) -> jack_nframes_t,
+        fn jack_cycle_wait( *mut jack_client_t) -> jack_nframes_t,
+        fn jack_cycle_signal( *mut jack_client_t, ::libc::c_int) -> (),
+        fn jack_set_process_thread(
+            *mut jack_client_t,
+            JackThreadCallback,
+            *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_thread_init_callback(
+             *mut jack_client_t,
+             JackThreadInitCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_on_shutdown(
+             *mut jack_client_t,
+             JackShutdownCallback,
+             *mut ::libc::c_void
+        ) -> (),
+        fn jack_on_info_shutdown(
+             *mut jack_client_t,
+             JackInfoShutdownCallback,
+             *mut ::libc::c_void
+        ) -> (),
+        fn jack_set_process_callback(
+             *mut jack_client_t,
+             JackProcessCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_freewheel_callback(
+             *mut jack_client_t,
+             JackFreewheelCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_buffer_size_callback(
+             *mut jack_client_t,
+             JackBufferSizeCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_sample_rate_callback(
+             *mut jack_client_t,
+             JackSampleRateCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_client_registration_callback(
+             *mut jack_client_t,
+             JackClientRegistrationCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_port_registration_callback(
+             *mut jack_client_t,
+             JackPortRegistrationCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_port_connect_callback(
+             *mut jack_client_t,
+             JackPortConnectCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_port_rename_callback(
+             *mut jack_client_t,
+             JackPortRenameCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_graph_order_callback(
+             *mut jack_client_t,
+             JackGraphOrderCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_xrun_callback(
+             *mut jack_client_t,
+             JackXRunCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_latency_callback(
+             *mut jack_client_t,
+             JackLatencyCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_set_freewheel( *mut jack_client_t,  ::libc::c_int) -> ::libc::c_int,
+        fn jack_set_buffer_size(
+             *mut jack_client_t,
+             jack_nframes_t
+        ) -> ::libc::c_int,
+        fn jack_get_sample_rate( *mut jack_client_t) -> jack_nframes_t,
+        fn jack_get_buffer_size( *mut jack_client_t) -> jack_nframes_t,
+        fn jack_engine_takeover_timebase( *mut jack_client_t) -> ::libc::c_int,
+        fn jack_cpu_load( *mut jack_client_t) -> ::libc::c_float,
+        fn jack_port_register(
+             *mut jack_client_t,
+             *const ::libc::c_char,
+             *const ::libc::c_char,
+             ::libc::c_ulong,
+             ::libc::c_ulong
+        ) -> *mut jack_port_t,
+        fn jack_port_unregister(
+             *mut jack_client_t,
+             *mut jack_port_t
+        ) -> ::libc::c_int,
+        fn jack_port_get_buffer(
+             *mut jack_port_t,
+             jack_nframes_t
+        ) -> *mut ::libc::c_void,
+        fn jack_port_uuid( *const jack_port_t) -> jack_uuid_t,
+        fn jack_port_name( *const jack_port_t) -> *const ::libc::c_char,
+        fn jack_port_short_name( *const jack_port_t) -> *const ::libc::c_char,
+        fn jack_port_flags( *const jack_port_t) -> ::libc::c_int,
+        fn jack_port_type( *const jack_port_t) -> *const ::libc::c_char,
+        fn jack_port_type_id( *const jack_port_t) -> jack_port_type_id_t,
+        fn jack_port_is_mine(
+             *const jack_client_t,
+             *const jack_port_t
+        ) -> ::libc::c_int,
+        fn jack_port_connected( *const jack_port_t) -> ::libc::c_int,
+        fn jack_port_connected_to(
+             *const jack_port_t,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_port_get_connections( *const jack_port_t) -> *mut *const ::libc::c_char,
+        fn jack_port_get_all_connections(
+             *const jack_client_t,
+             *const jack_port_t
+        ) -> *mut *const ::libc::c_char,
+        fn jack_port_tie( *mut jack_port_t,  *mut jack_port_t) -> ::libc::c_int,
+        fn jack_port_untie( *mut jack_port_t) -> ::libc::c_int,
+        fn jack_port_set_name(
+             *mut jack_port_t,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_port_set_alias(
+             *mut jack_port_t,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_port_unset_alias(
+             *mut jack_port_t,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_port_get_aliases(
+             *const jack_port_t,
+             *mut *mut ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_port_request_monitor( *mut jack_port_t,  ::libc::c_int)
+            -> ::libc::c_int,
+        fn jack_port_request_monitor_by_name(
+             *mut jack_client_t,
+             *const ::libc::c_char,
+             ::libc::c_int
+        ) -> ::libc::c_int,
+        fn jack_port_ensure_monitor( *mut jack_port_t,  ::libc::c_int) -> ::libc::c_int,
+        fn jack_port_monitoring_input( *mut jack_port_t) -> ::libc::c_int,
+        fn jack_connect(
+             *mut jack_client_t,
+             *const ::libc::c_char,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_disconnect(
+             *mut jack_client_t,
+             *const ::libc::c_char,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_port_disconnect(
+             *mut jack_client_t,
+             *mut jack_port_t
+        ) -> ::libc::c_int,
+        fn jack_port_name_size() -> ::libc::c_int,
+        fn jack_port_type_size() -> ::libc::c_int,
+        fn jack_port_type_get_buffer_size(
+             *mut jack_client_t,
+             *const ::libc::c_char
+        ) -> ::libc::size_t,
+        fn jack_port_set_latency( *mut jack_port_t,  jack_nframes_t) -> (),
+        fn jack_port_get_latency_range(
+             *mut jack_port_t,
+             jack_latency_callback_mode_t,
+             *mut jack_latency_range_t
+        ) -> (),
+        fn jack_port_set_latency_range(
+             *mut jack_port_t,
+             jack_latency_callback_mode_t,
+             *mut jack_latency_range_t
+        ) -> (),
+        fn jack_recompute_total_latencies( *mut jack_client_t) -> ::libc::c_int,
+        fn jack_port_get_latency( *mut jack_port_t) -> jack_nframes_t,
+        fn jack_port_get_total_latency(
+             *mut jack_client_t,
+             *mut jack_port_t
+        ) -> jack_nframes_t,
+        fn jack_recompute_total_latency(
+             *mut jack_client_t,
+             *mut jack_port_t
+        ) -> ::libc::c_int,
+        fn jack_get_ports(
+             *mut jack_client_t,
+             *const ::libc::c_char,
+             *const ::libc::c_char,
+             ::libc::c_ulong
+        ) -> *mut *const ::libc::c_char,
+        fn jack_port_by_name(
+             *mut jack_client_t,
+             *const ::libc::c_char
+        ) -> *mut jack_port_t,
+        fn jack_port_by_id( *mut jack_client_t,  jack_port_id_t)
+            -> *mut jack_port_t,
+        fn jack_frames_since_cycle_start( *const jack_client_t) -> jack_nframes_t,
+        fn jack_frame_time( *const jack_client_t) -> jack_nframes_t,
+        fn jack_last_frame_time( *const jack_client_t) -> jack_nframes_t,
 
-    pub fn jack_frames_to_time(client: *const jack_client_t, arg1: jack_nframes_t) -> jack_time_t;
-    pub fn jack_time_to_frames(client: *const jack_client_t, arg1: jack_time_t) -> jack_nframes_t;
-    pub fn jack_get_time() -> jack_time_t;
-    pub fn jack_set_error_function(
-        func: ::std::option::Option<unsafe extern "C" fn(arg1: *const ::libc::c_char) -> ()>,
-    ) -> ();
-    pub fn jack_set_info_function(
-        func: ::std::option::Option<unsafe extern "C" fn(arg1: *const ::libc::c_char) -> ()>,
-    ) -> ();
-    pub fn jack_free(ptr: *mut ::libc::c_void) -> ();
-    pub fn jack_client_real_time_priority(arg1: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_client_max_real_time_priority(arg1: *mut jack_client_t) -> ::libc::c_int;
-    #[cfg(not(target_os = "windows"))]
-    pub fn jack_acquire_real_time_scheduling(
-        thread: jack_native_thread_t,
-        priority: ::libc::c_int,
-    ) -> ::libc::c_int;
-    #[cfg(not(target_os = "windows"))]
-    pub fn jack_client_create_thread(
-        client: *mut jack_client_t,
-        thread: *mut jack_native_thread_t,
-        priority: ::libc::c_int,
-        realtime: ::libc::c_int,
-        start_routine: ::std::option::Option<
-            unsafe extern "C" fn(arg1: *mut ::libc::c_void) -> *mut ::libc::c_void,
-        >,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    #[cfg(not(target_os = "windows"))]
-    pub fn jack_drop_real_time_scheduling(thread: jack_native_thread_t) -> ::libc::c_int;
-    #[cfg(not(target_os = "windows"))]
-    pub fn jack_client_stop_thread(
-        client: *mut jack_client_t,
-        thread: jack_native_thread_t,
-    ) -> ::libc::c_int;
-    #[cfg(not(target_os = "windows"))]
-    pub fn jack_client_kill_thread(
-        client: *mut jack_client_t,
-        thread: jack_native_thread_t,
-    ) -> ::libc::c_int;
-    #[cfg(not(target_os = "windows"))]
-    pub fn jack_set_thread_creator(creator: jack_thread_creator_t) -> ();
-    pub fn jack_set_session_callback(
-        client: *mut jack_client_t,
-        session_callback: JackSessionCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_session_reply(
-        client: *mut jack_client_t,
-        event: *mut jack_session_event_t,
-    ) -> ::libc::c_int;
-    pub fn jack_session_event_free(event: *mut jack_session_event_t) -> ();
-    pub fn jack_client_get_uuid(client: *mut jack_client_t) -> *mut ::libc::c_char;
-    pub fn jack_session_notify(
-        client: *mut jack_client_t,
-        target: *const ::libc::c_char,
-        _type: jack_session_event_type_t,
-        path: *const ::libc::c_char,
-    ) -> *mut jack_session_command_t;
-    pub fn jack_session_commands_free(cmds: *mut jack_session_command_t) -> ();
-    pub fn jack_reserve_client_name(
-        client: *mut jack_client_t,
-        name: *const ::libc::c_char,
-        uuid: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_client_has_session_callback(
-        client: *mut jack_client_t,
-        client_name: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jackctl_setup_signals(flags: ::libc::c_uint) -> *mut jackctl_sigmask_t;
-    pub fn jackctl_wait_signals(signals: *mut jackctl_sigmask_t) -> ();
-    pub fn jackctl_server_create(
-        on_device_acquire: ::std::option::Option<
-            unsafe extern "C" fn(device_name: *const ::libc::c_char) -> u8,
-        >,
-        on_device_release: ::std::option::Option<
-            unsafe extern "C" fn(device_name: *const ::libc::c_char) -> (),
-        >,
-    ) -> *mut jackctl_server_t;
-    pub fn jackctl_server_destroy(server: *mut jackctl_server_t) -> ();
-    pub fn jackctl_server_open(server: *mut jackctl_server_t, driver: *mut jackctl_driver_t) -> u8;
-    pub fn jackctl_server_start(server: *mut jackctl_server_t) -> u8;
-    pub fn jackctl_server_stop(server: *mut jackctl_server_t) -> u8;
-    pub fn jackctl_server_close(server: *mut jackctl_server_t) -> u8;
-    pub fn jackctl_server_get_drivers_list(server: *mut jackctl_server_t) -> *const JSList;
-    pub fn jackctl_server_get_parameters(server: *mut jackctl_server_t) -> *const JSList;
-    pub fn jackctl_server_get_internals_list(server: *mut jackctl_server_t) -> *const JSList;
-    pub fn jackctl_server_load_internal(
-        server: *mut jackctl_server_t,
-        internal: *mut jackctl_internal_t,
-    ) -> u8;
-    pub fn jackctl_server_unload_internal(
-        server: *mut jackctl_server_t,
-        internal: *mut jackctl_internal_t,
-    ) -> u8;
-    pub fn jackctl_server_add_slave(
-        server: *mut jackctl_server_t,
-        driver: *mut jackctl_driver_t,
-    ) -> u8;
-    pub fn jackctl_server_remove_slave(
-        server: *mut jackctl_server_t,
-        driver: *mut jackctl_driver_t,
-    ) -> u8;
-    pub fn jackctl_server_switch_master(
-        server: *mut jackctl_server_t,
-        driver: *mut jackctl_driver_t,
-    ) -> u8;
-    pub fn jackctl_driver_get_name(driver: *mut jackctl_driver_t) -> *const ::libc::c_char;
-    pub fn jackctl_driver_get_type(driver: *mut jackctl_driver_t) -> jackctl_driver_type_t;
-    pub fn jackctl_driver_get_parameters(driver: *mut jackctl_driver_t) -> *const JSList;
-    pub fn jackctl_driver_params_parse(
-        driver: *mut jackctl_driver_t,
-        argc: ::libc::c_int,
-        argv: *mut *mut ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jackctl_internal_get_name(internal: *mut jackctl_internal_t) -> *const ::libc::c_char;
-    pub fn jackctl_internal_get_parameters(internal: *mut jackctl_internal_t) -> *const JSList;
-    pub fn jackctl_parameter_get_name(parameter: *mut jackctl_parameter_t)
-        -> *const ::libc::c_char;
-    pub fn jackctl_parameter_get_short_description(
-        parameter: *mut jackctl_parameter_t,
-    ) -> *const ::libc::c_char;
-    pub fn jackctl_parameter_get_long_description(
-        parameter: *mut jackctl_parameter_t,
-    ) -> *const ::libc::c_char;
-    pub fn jackctl_parameter_get_type(parameter: *mut jackctl_parameter_t) -> jackctl_param_type_t;
-    pub fn jackctl_parameter_get_id(parameter: *mut jackctl_parameter_t) -> ::libc::c_char;
-    pub fn jackctl_parameter_is_set(parameter: *mut jackctl_parameter_t) -> u8;
-    pub fn jackctl_parameter_reset(parameter: *mut jackctl_parameter_t) -> u8;
-    pub fn jackctl_parameter_get_value(
-        parameter: *mut jackctl_parameter_t,
-    ) -> Union_jackctl_parameter_value;
-    pub fn jackctl_parameter_set_value(
-        parameter: *mut jackctl_parameter_t,
-        value_ptr: *const Union_jackctl_parameter_value,
-    ) -> u8;
-    pub fn jackctl_parameter_get_default_value(
-        parameter: *mut jackctl_parameter_t,
-    ) -> Union_jackctl_parameter_value;
-    pub fn jackctl_parameter_has_range_constraint(parameter: *mut jackctl_parameter_t) -> u8;
-    pub fn jackctl_parameter_has_enum_constraint(parameter: *mut jackctl_parameter_t) -> u8;
-    pub fn jackctl_parameter_get_enum_constraints_count(parameter: *mut jackctl_parameter_t)
-        -> u32;
-    pub fn jackctl_parameter_get_enum_constraint_value(
-        parameter: *mut jackctl_parameter_t,
-        index: u32,
-    ) -> Union_jackctl_parameter_value;
-    pub fn jackctl_parameter_get_enum_constraint_description(
-        parameter: *mut jackctl_parameter_t,
-        index: u32,
-    ) -> *const ::libc::c_char;
-    pub fn jackctl_parameter_get_range_constraint(
-        parameter: *mut jackctl_parameter_t,
-        min_ptr: *mut Union_jackctl_parameter_value,
-        max_ptr: *mut Union_jackctl_parameter_value,
-    ) -> ();
-    pub fn jackctl_parameter_constraint_is_strict(parameter: *mut jackctl_parameter_t) -> u8;
-    pub fn jackctl_parameter_constraint_is_fake_value(parameter: *mut jackctl_parameter_t) -> u8;
-    pub fn jack_error(format: *const ::libc::c_char, ...) -> ();
-    pub fn jack_info(format: *const ::libc::c_char, ...) -> ();
-    pub fn jack_log(format: *const ::libc::c_char, ...) -> ();
-    pub fn jack_set_property(
-        arg1: *mut jack_client_t,
-        subject: jack_uuid_t,
-        key: *const ::libc::c_char,
-        value: *const ::libc::c_char,
-        _type: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_get_property(
-        subject: jack_uuid_t,
-        key: *const ::libc::c_char,
-        value: *mut *mut ::libc::c_char,
-        _type: *mut *mut ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_free_description(
-        desc: *mut jack_description_t,
-        free_description_itself: ::libc::c_int,
-    ) -> ();
-    pub fn jack_get_properties(
-        subject: jack_uuid_t,
-        desc: *mut jack_description_t,
-    ) -> ::libc::c_int;
-    pub fn jack_get_all_properties(descs: *mut *mut jack_description_t) -> ::libc::c_int;
-    pub fn jack_remove_property(
-        client: *mut jack_client_t,
-        subject: jack_uuid_t,
-        key: *const ::libc::c_char,
-    ) -> ::libc::c_int;
-    pub fn jack_remove_properties(
-        client: *mut jack_client_t,
-        subject: jack_uuid_t,
-    ) -> ::libc::c_int;
-    pub fn jack_remove_all_properties(client: *mut jack_client_t) -> ::libc::c_int;
-    pub fn jack_set_property_change_callback(
-        client: *mut jack_client_t,
-        callback: JackPropertyChangeCallback,
-        arg: *mut ::libc::c_void,
-    ) -> ::libc::c_int;
-    pub fn jack_get_internal_client_name(
-        client: *mut jack_client_t,
-        intclient: jack_intclient_t,
-    ) -> *mut ::libc::c_char;
-    pub fn jack_internal_client_handle(
-        client: *mut jack_client_t,
-        client_name: *const ::libc::c_char,
-        status: *mut jack_status_t,
-    ) -> jack_intclient_t;
-    pub fn jack_internal_client_load(
-        client: *mut jack_client_t,
-        client_name: *const ::libc::c_char,
-        options: jack_options_t,
-        status: *mut jack_status_t,
-        ...
-    ) -> jack_intclient_t;
-    pub fn jack_internal_client_unload(
-        client: *mut jack_client_t,
-        intclient: jack_intclient_t,
-    ) -> jack_status_t;
-    pub fn jack_get_max_delayed_usecs(client: *mut jack_client_t) -> ::libc::c_float;
-    pub fn jack_get_xrun_delayed_usecs(client: *mut jack_client_t) -> ::libc::c_float;
-    pub fn jack_reset_max_delayed_usecs(client: *mut jack_client_t) -> ();
-    pub fn jack_midi_get_event_count(port_buffer: *mut ::libc::c_void) -> u32;
-    pub fn jack_midi_event_get(
-        event: *mut jack_midi_event_t,
-        port_buffer: *mut ::libc::c_void,
-        event_index: u32,
-    ) -> ::libc::c_int;
-    pub fn jack_midi_clear_buffer(port_buffer: *mut ::libc::c_void) -> ();
-    pub fn jack_midi_reset_buffer(port_buffer: *mut ::libc::c_void) -> ();
-    pub fn jack_midi_max_event_size(port_buffer: *mut ::libc::c_void) -> ::libc::size_t;
-    pub fn jack_midi_event_reserve(
-        port_buffer: *mut ::libc::c_void,
-        time: jack_nframes_t,
-        data_size: ::libc::size_t,
-    ) -> *mut jack_midi_data_t;
-    pub fn jack_midi_event_write(
-        port_buffer: *mut ::libc::c_void,
-        time: jack_nframes_t,
-        data: *const jack_midi_data_t,
-        data_size: ::libc::size_t,
-    ) -> ::libc::c_int;
-    pub fn jack_midi_get_lost_event_count(port_buffer: *mut ::libc::c_void) -> u32;
-    pub fn jack_ringbuffer_create(sz: ::libc::size_t) -> *mut jack_ringbuffer_t;
-    pub fn jack_ringbuffer_free(rb: *mut jack_ringbuffer_t) -> ();
-    pub fn jack_ringbuffer_get_read_vector(
-        rb: *const jack_ringbuffer_t,
-        vec: *mut jack_ringbuffer_data_t,
-    ) -> ();
-    pub fn jack_ringbuffer_get_write_vector(
-        rb: *const jack_ringbuffer_t,
-        vec: *mut jack_ringbuffer_data_t,
-    ) -> ();
-    pub fn jack_ringbuffer_read(
-        rb: *mut jack_ringbuffer_t,
-        dest: *mut ::libc::c_char,
-        cnt: ::libc::size_t,
-    ) -> ::libc::size_t;
-    pub fn jack_ringbuffer_peek(
-        rb: *mut jack_ringbuffer_t,
-        dest: *mut ::libc::c_char,
-        cnt: ::libc::size_t,
-    ) -> ::libc::size_t;
-    pub fn jack_ringbuffer_read_advance(rb: *mut jack_ringbuffer_t, cnt: ::libc::size_t) -> ();
-    pub fn jack_ringbuffer_read_space(rb: *const jack_ringbuffer_t) -> ::libc::size_t;
-    pub fn jack_ringbuffer_mlock(rb: *mut jack_ringbuffer_t) -> ::libc::c_int;
-    pub fn jack_ringbuffer_reset(rb: *mut jack_ringbuffer_t) -> ();
-    pub fn jack_ringbuffer_reset_size(rb: *mut jack_ringbuffer_t, sz: ::libc::size_t) -> ();
-    pub fn jack_ringbuffer_write(
-        rb: *mut jack_ringbuffer_t,
-        src: *const ::libc::c_char,
-        cnt: ::libc::size_t,
-    ) -> ::libc::size_t;
-    pub fn jack_ringbuffer_write_advance(rb: *mut jack_ringbuffer_t, cnt: ::libc::size_t) -> ();
-    pub fn jack_ringbuffer_write_space(rb: *const jack_ringbuffer_t) -> ::libc::size_t;
-
-}
+        fn jack_frames_to_time( *const jack_client_t,  jack_nframes_t) -> jack_time_t,
+        fn jack_time_to_frames( *const jack_client_t,  jack_time_t) -> jack_nframes_t,
+        fn jack_get_time() -> jack_time_t,
+        fn jack_set_error_function(
+             ::std::option::Option<unsafe extern "C" fn(*const ::libc::c_char) -> ()>
+        ) -> (),
+        fn jack_set_info_function(
+             ::std::option::Option<unsafe extern "C" fn(*const ::libc::c_char) -> ()>
+        ) -> (),
+        fn jack_free(*mut ::libc::c_void) -> (),
+        fn jack_client_real_time_priority( *mut jack_client_t) -> ::libc::c_int,
+        fn jack_client_max_real_time_priority( *mut jack_client_t) -> ::libc::c_int,
+        // #[cfg(not(target_os = "windows"))]
+        // fn jack_acquire_real_time_scheduling(
+        //     thread: jack_native_thread_t,
+        //     priority: ::libc::c_int,
+        // ) -> ::libc::c_int,
+        // #[cfg(not(target_os = "windows"))]
+        // fn jack_client_create_thread(
+        //     client: *mut jack_client_t,
+        //     thread: *mut jack_native_thread_t,
+        //     priority: ::libc::c_int,
+        //     realtime: ::libc::c_int,
+        //     start_routine: ::std::option::Option<
+        //         unsafe extern "C" fn(arg1: *mut ::libc::c_void) -> *mut ::libc::c_void,
+        //     >,
+        //     arg: *mut ::libc::c_void,
+        // ) -> ::libc::c_int,
+        // #[cfg(not(target_os = "windows"))]
+        // fn jack_drop_real_time_scheduling(thread: jack_native_thread_t) -> ::libc::c_int,
+        // #[cfg(not(target_os = "windows"))]
+        // fn jack_client_stop_thread(
+        //     client: *mut jack_client_t,
+        //     thread: jack_native_thread_t,
+        // ) -> ::libc::c_int,
+        // #[cfg(not(target_os = "windows"))]
+        // fn jack_client_kill_thread(
+        //     client: *mut jack_client_t,
+        //     thread: jack_native_thread_t,
+        // ) -> ::libc::c_int,
+        // #[cfg(not(target_os = "windows"))]
+        // fn jack_set_thread_creator(creator: jack_thread_creator_t) -> (),
+        fn jack_set_session_callback(
+             *mut jack_client_t,
+             JackSessionCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_session_reply(
+             *mut jack_client_t,
+             *mut jack_session_event_t
+        ) -> ::libc::c_int,
+        fn jack_session_event_free( *mut jack_session_event_t) -> (),
+        fn jack_client_get_uuid( *mut jack_client_t) -> *mut ::libc::c_char,
+        fn jack_session_notify(
+             *mut jack_client_t,
+             *const ::libc::c_char,
+             jack_session_event_type_t,
+             *const ::libc::c_char
+        ) -> *mut jack_session_command_t,
+        fn jack_session_commands_free(*mut jack_session_command_t) -> (),
+        fn jack_reserve_client_name(
+             *mut jack_client_t,
+             *const ::libc::c_char,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_client_has_session_callback(
+            *mut jack_client_t,
+            *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jackctl_setup_signals(::libc::c_uint) -> *mut jackctl_sigmask_t,
+        fn jackctl_wait_signals(*mut jackctl_sigmask_t) -> (),
+        fn jackctl_server_create(
+            ::std::option::Option<
+                unsafe extern "C" fn(*const ::libc::c_char) -> u8,
+            >,
+            ::std::option::Option<
+                unsafe extern "C" fn(*const ::libc::c_char) -> (),
+            >
+        ) -> *mut jackctl_server_t,
+        fn jackctl_server_destroy(*mut jackctl_server_t) -> (),
+        fn jackctl_server_open(*mut jackctl_server_t, *mut jackctl_driver_t) -> u8,
+        fn jackctl_server_start(*mut jackctl_server_t) -> u8,
+        fn jackctl_server_stop(*mut jackctl_server_t) -> u8,
+        fn jackctl_server_close(*mut jackctl_server_t) -> u8,
+        fn jackctl_server_get_drivers_list(*mut jackctl_server_t) -> *const JSList,
+        fn jackctl_server_get_parameters(*mut jackctl_server_t) -> *const JSList,
+        fn jackctl_server_get_internals_list(*mut jackctl_server_t) -> *const JSList,
+        fn jackctl_server_load_internal(
+            *mut jackctl_server_t,
+            *mut jackctl_internal_t
+        ) -> u8,
+        fn jackctl_server_unload_internal(
+            *mut jackctl_server_t,
+            *mut jackctl_internal_t
+        ) -> u8,
+        fn jackctl_server_add_slave(
+            *mut jackctl_server_t,
+            *mut jackctl_driver_t
+        ) -> u8,
+        fn jackctl_server_remove_slave(
+            *mut jackctl_server_t,
+            *mut jackctl_driver_t
+        ) -> u8,
+        fn jackctl_server_switch_master(
+            *mut jackctl_server_t,
+            *mut jackctl_driver_t
+        ) -> u8,
+        fn jackctl_driver_get_name( *mut jackctl_driver_t) -> *const ::libc::c_char,
+        fn jackctl_driver_get_type( *mut jackctl_driver_t) -> jackctl_driver_type_t,
+        fn jackctl_driver_get_parameters( *mut jackctl_driver_t) -> *const JSList,
+        fn jackctl_driver_params_parse(
+            *mut jackctl_driver_t,
+            ::libc::c_int,
+            *mut *mut ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jackctl_internal_get_name(*mut jackctl_internal_t) -> *const ::libc::c_char,
+        fn jackctl_internal_get_parameters(*mut jackctl_internal_t) -> *const JSList,
+        fn jackctl_parameter_get_name(*mut jackctl_parameter_t)
+            -> *const ::libc::c_char,
+        fn jackctl_parameter_get_short_description(
+            *mut jackctl_parameter_t
+        ) -> *const ::libc::c_char,
+        fn jackctl_parameter_get_long_description(
+            *mut jackctl_parameter_t
+        ) -> *const ::libc::c_char,
+        fn jackctl_parameter_get_type(*mut jackctl_parameter_t) -> jackctl_param_type_t,
+        fn jackctl_parameter_get_id(*mut jackctl_parameter_t) -> ::libc::c_char,
+        fn jackctl_parameter_is_set(*mut jackctl_parameter_t) -> u8,
+        fn jackctl_parameter_reset(*mut jackctl_parameter_t) -> u8,
+        fn jackctl_parameter_get_value(
+            *mut jackctl_parameter_t
+        ) -> Union_jackctl_parameter_value,
+        fn jackctl_parameter_set_value(
+            *mut jackctl_parameter_t,
+            *const Union_jackctl_parameter_value
+        ) -> u8,
+        fn jackctl_parameter_get_default_value(
+            *mut jackctl_parameter_t
+        ) -> Union_jackctl_parameter_value,
+        fn jackctl_parameter_has_range_constraint(*mut jackctl_parameter_t) -> u8,
+        fn jackctl_parameter_has_enum_constraint(*mut jackctl_parameter_t) -> u8,
+        fn jackctl_parameter_get_enum_constraints_count(*mut jackctl_parameter_t)
+            -> u32,
+        fn jackctl_parameter_get_enum_constraint_value(
+            *mut jackctl_parameter_t,
+            u32
+        ) -> Union_jackctl_parameter_value,
+        fn jackctl_parameter_get_enum_constraint_description(
+            *mut jackctl_parameter_t,
+            u32
+        ) -> *const ::libc::c_char,
+        fn jackctl_parameter_get_range_constraint(
+            *mut jackctl_parameter_t,
+            *mut Union_jackctl_parameter_value,
+            *mut Union_jackctl_parameter_value
+        ) -> (),
+        fn jackctl_parameter_constraint_is_strict(*mut jackctl_parameter_t) -> u8,
+        fn jackctl_parameter_constraint_is_fake_value(*mut jackctl_parameter_t) -> u8,
+        // fn jack_error(format: *const ::libc::c_char, ...) -> (),
+        // fn jack_info(format: *const ::libc::c_char, ...) -> (),
+        // fn jack_log(format: *const ::libc::c_char, ...) -> (),
+        fn jack_set_property(
+            *mut jack_client_t,
+            jack_uuid_t,
+            *const ::libc::c_char,
+            *const ::libc::c_char,
+            *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_get_property(
+            jack_uuid_t,
+            *const ::libc::c_char,
+            *mut *mut ::libc::c_char,
+            *mut *mut ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_free_description(
+            *mut jack_description_t,
+            ::libc::c_int
+        ) -> (),
+        fn jack_get_properties(
+            jack_uuid_t,
+            *mut jack_description_t
+        ) -> ::libc::c_int,
+        fn jack_get_all_properties(*mut *mut jack_description_t) -> ::libc::c_int,
+        fn jack_remove_property(
+             *mut jack_client_t,
+             jack_uuid_t,
+             *const ::libc::c_char
+        ) -> ::libc::c_int,
+        fn jack_remove_properties(
+             *mut jack_client_t,
+             jack_uuid_t
+        ) -> ::libc::c_int,
+        fn jack_remove_all_properties( *mut jack_client_t) -> ::libc::c_int,
+        fn jack_set_property_change_callback(
+             *mut jack_client_t,
+             JackPropertyChangeCallback,
+             *mut ::libc::c_void
+        ) -> ::libc::c_int,
+        fn jack_get_internal_client_name(
+             *mut jack_client_t,
+             jack_intclient_t
+        ) -> *mut ::libc::c_char,
+        fn jack_internal_client_handle(
+             *mut jack_client_t,
+             *const ::libc::c_char,
+             *mut jack_status_t
+        ) -> jack_intclient_t,
+        fn jack_internal_client_unload(
+             *mut jack_client_t,
+             jack_intclient_t
+        ) -> jack_status_t,
+        fn jack_get_max_delayed_usecs(*mut jack_client_t) -> ::libc::c_float,
+        fn jack_get_xrun_delayed_usecs( *mut jack_client_t) -> ::libc::c_float,
+        fn jack_reset_max_delayed_usecs( *mut jack_client_t) -> (),
+        fn jack_midi_get_event_count( *mut ::libc::c_void) -> u32,
+        fn jack_midi_event_get(
+             *mut jack_midi_event_t,
+             *mut ::libc::c_void,
+             u32
+        ) -> ::libc::c_int,
+        fn jack_midi_clear_buffer(*mut ::libc::c_void) -> (),
+        fn jack_midi_reset_buffer(*mut ::libc::c_void) -> (),
+        fn jack_midi_max_event_size(*mut ::libc::c_void) -> ::libc::size_t,
+        fn jack_midi_event_reserve(
+            *mut ::libc::c_void,
+            jack_nframes_t,
+            ::libc::size_t
+        ) -> *mut jack_midi_data_t,
+        fn jack_midi_event_write(
+            *mut ::libc::c_void,
+            jack_nframes_t,
+            *const jack_midi_data_t,
+            ::libc::size_t
+        ) -> ::libc::c_int,
+        fn jack_midi_get_lost_event_count( *mut ::libc::c_void) -> u32,
+        fn jack_ringbuffer_create( ::libc::size_t) -> *mut jack_ringbuffer_t,
+        fn jack_ringbuffer_free( *mut jack_ringbuffer_t) -> (),
+        fn jack_ringbuffer_get_read_vector(
+             *const jack_ringbuffer_t,
+             *mut jack_ringbuffer_data_t
+        ) -> (),
+        fn jack_ringbuffer_get_write_vector(
+             *const jack_ringbuffer_t,
+             *mut jack_ringbuffer_data_t
+        ) -> (),
+        fn jack_ringbuffer_read(
+             *mut jack_ringbuffer_t,
+             *mut ::libc::c_char,
+             ::libc::size_t
+        ) -> ::libc::size_t,
+        fn jack_ringbuffer_peek(
+            *mut jack_ringbuffer_t,
+            *mut ::libc::c_char,
+            ::libc::size_t
+        ) -> ::libc::size_t,
+        fn jack_ringbuffer_read_advance(*mut jack_ringbuffer_t,  ::libc::size_t) -> (),
+        fn jack_ringbuffer_read_space( *const jack_ringbuffer_t) -> ::libc::size_t,
+        fn jack_ringbuffer_mlock( *mut jack_ringbuffer_t) -> ::libc::c_int,
+        fn jack_ringbuffer_reset( *mut jack_ringbuffer_t) -> (),
+        fn jack_ringbuffer_reset_size( *mut jack_ringbuffer_t,  ::libc::size_t) -> (),
+        fn jack_ringbuffer_write(
+             *mut jack_ringbuffer_t,
+             *const ::libc::c_char,
+             ::libc::size_t
+        ) -> ::libc::size_t,
+        fn jack_ringbuffer_write_advance( *mut jack_ringbuffer_t,  ::libc::size_t) -> (),
+        fn jack_ringbuffer_write_space( *const jack_ringbuffer_t) -> ::libc::size_t,
+    varargs:
+        fn jack_internal_client_load(
+            *mut jack_client_t,
+            *const ::libc::c_char,
+            jack_options_t,
+            *mut jack_status_t,
+            *mut jack_status_t,
+            *mut jack_status_t
+        ) -> jack_intclient_t,
+        fn jack_client_open(*const ::libc::c_char, jack_options_t, *mut jack_status_t) -> *mut jack_client_t,
+);
 
 extern "C" {
     pub fn jack_uuid_to_index(arg1: jack_uuid_t) -> u32;
@@ -1092,7 +1093,7 @@ type jack_get_cycle_times_t = unsafe extern "C" fn(
 
 lazy_static! {
     pub static ref jack_get_cycle_times: Option<jack_get_cycle_times_t> = {
-        libloading::Library::new(jack_lib)
+        unsafe { libloading::Library::new(jack_lib) }
             .ok()
             .and_then(|lib| unsafe {
                 lib.get::<jack_get_cycle_times_t>(b"jack_get_cycle_times\0")

--- a/jack-sys/src/lib.rs
+++ b/jack-sys/src/lib.rs
@@ -1056,8 +1056,7 @@ external_library!(
             *const ::libc::c_char,
             jack_options_t,
             *mut jack_status_t,
-            *mut jack_status_t,
-            *mut jack_status_t
+            jack_intclient_t
         ) -> jack_intclient_t,
         fn jack_client_open(*const ::libc::c_char, jack_options_t, *mut jack_status_t) -> *mut jack_client_t,
 );

--- a/jack-sys/src/lib.rs
+++ b/jack-sys/src/lib.rs
@@ -487,12 +487,7 @@ impl ::std::default::Default for Struct_Unnamed12 {
     }
 }
 pub type jack_ringbuffer_t = Struct_Unnamed12;
-extern "C" {
-    pub static mut jack_error_callback:
-        ::std::option::Option<unsafe extern "C" fn(msg: *const ::libc::c_char) -> ()>;
-    pub static mut jack_info_callback:
-        ::std::option::Option<unsafe extern "C" fn(msg: *const ::libc::c_char) -> ()>;
-}
+extern "C" {}
 
 external_library!(
     JackMetadata,
@@ -504,12 +499,24 @@ external_library!(
     JACK_METADATA_ICON_SMALL: *const ::libc::c_char,
     JACK_METADATA_ICON_LARGE: *const ::libc::c_char,
 );
+// statics:
+// // jack_error_callback:
+// //     ::std::option::Option<unsafe extern "C" fn(*const ::libc::c_char) -> ()>,
+// // jack_info_callback:
+// //     ::std::option::Option<unsafe extern "C" fn(*const ::libc::c_char) -> ()>,
+
+external_library!(
+    JackError,
+    "jack",
+    statics: jack_error_callback: Option<unsafe extern "C" fn(*const ::libc::c_char) -> ()>,
+    jack_info_callback: Option<unsafe extern "C" fn(*const ::libc::c_char) -> ()>,
+);
 
 external_library!(
     JackLib,
     "jack",
         functions:
-            fn jack_release_timebase(*mut jack_client_t) -> ::libc::c_int,
+        fn jack_release_timebase(*mut jack_client_t) -> ::libc::c_int,
         fn jack_set_sync_callback(
              *mut jack_client_t,
              JackSyncCallback,
@@ -1061,18 +1068,21 @@ external_library!(
         fn jack_client_open(*const ::libc::c_char, jack_options_t, *mut jack_status_t) -> *mut jack_client_t,
 );
 
-extern "C" {
-    pub fn jack_uuid_to_index(arg1: jack_uuid_t) -> u32;
-    pub fn jack_uuid_compare(arg1: jack_uuid_t, arg2: jack_uuid_t) -> ::std::os::raw::c_int;
-    pub fn jack_uuid_copy(dst: *mut jack_uuid_t, src: jack_uuid_t);
-    pub fn jack_uuid_clear(arg1: *mut jack_uuid_t);
-    pub fn jack_uuid_parse(
-        buf: *const ::std::os::raw::c_char,
-        arg1: *mut jack_uuid_t,
-    ) -> ::std::os::raw::c_int;
-    pub fn jack_uuid_unparse(arg1: jack_uuid_t, buf: *mut ::std::os::raw::c_char);
-    pub fn jack_uuid_empty(arg1: jack_uuid_t) -> ::std::os::raw::c_int;
-}
+external_library!(
+    JackUuid,
+    "jack",
+    functions:
+    fn jack_uuid_to_index(jack_uuid_t) -> u32,
+    fn jack_uuid_copy(*mut jack_uuid_t, jack_uuid_t) -> (),
+    fn jack_uuid_compare(jack_uuid_t, jack_uuid_t) -> ::std::os::raw::c_int,
+    fn jack_uuid_clear(*mut jack_uuid_t) -> (),
+    fn jack_uuid_parse(
+        *const ::std::os::raw::c_char,
+        *mut jack_uuid_t
+    ) -> ::std::os::raw::c_int,
+    fn jack_uuid_unparse(jack_uuid_t, *mut ::std::os::raw::c_char) -> (),
+    fn jack_uuid_empty(jack_uuid_t) -> ::std::os::raw::c_int,
+);
 
 // Load optional functions:
 

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -315,7 +315,7 @@ impl Client {
                 ffi_client_name.as_ptr(),
                 options,
                 &mut status_bits,
-                ffi_client_bin.as_ptr(),
+                ffi_client_bin.as_ptr() as _,
                 ffi_client_args.as_ptr(),
             )
         };

--- a/src/port/midi.rs
+++ b/src/port/midi.rs
@@ -6,7 +6,7 @@ use crate::{Error, Frames, Port, PortFlags, PortSpec, ProcessScope};
 
 /// Contains 8bit raw midi information along with a timestamp relative to the
 /// process cycle.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub struct RawMidi<'a> {
     /// The amount of time passed, in frames, relative to the start of the
     /// process cycle
@@ -14,15 +14,6 @@ pub struct RawMidi<'a> {
 
     /// Midi data
     pub bytes: &'a [u8],
-}
-
-impl<'a> Default for RawMidi<'a> {
-    fn default() -> Self {
-        RawMidi {
-            time: 0,
-            bytes: &[],
-        }
-    }
 }
 
 /// `MidiIn` implements the `PortSpec` trait, which defines an endpoint for JACK. In this case, it

--- a/src/port/port_impl.rs
+++ b/src/port/port_impl.rs
@@ -19,6 +19,10 @@ lazy_static! {
 
 /// Defines the configuration for a certain port to JACK, ie 32 bit floating audio input, 8 bit raw
 /// midi output, etc...
+///
+/// # Safety
+/// Making your own JACK type is risky. You probably want to use an existing
+/// type. For new types, make sure to have a well defined spec of the behavior.
 pub unsafe trait PortSpec: Sized {
     /// String used by JACK upon port creation to identify the port
     /// type.


### PR DESCRIPTION
Supports #159 for `jack-sys`. Follow up is to use `dlib` in `jack`.