### PR TITLE
remove Sync requirement from NotificationHandler

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "jack"
 readme = "README.md"
 repository = "https://github.com/RustAudio/rust-jack"
-version = "0.9.0"
+version = "0.9.1"
 
 [dependencies]
 bitflags = "1"

--- a/src/client/async_client.rs
+++ b/src/client/async_client.rs
@@ -43,7 +43,7 @@ unsafe impl<N, P> Sync for AsyncClient<N, P> {}
 
 impl<N, P> AsyncClient<N, P>
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     /// Tell the JACK server that the program is ready to start processing audio. JACK will call the

--- a/src/client/callbacks.rs
+++ b/src/client/callbacks.rs
@@ -104,7 +104,7 @@ pub trait ProcessHandler: Send {
 
 unsafe extern "C" fn thread_init_callback<N, P>(data: *mut libc::c_void)
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -116,7 +116,7 @@ unsafe extern "C" fn shutdown<N, P>(
     reason: *const libc::c_char,
     data: *mut libc::c_void,
 ) where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -130,7 +130,7 @@ unsafe extern "C" fn shutdown<N, P>(
 
 unsafe extern "C" fn process<N, P>(n_frames: Frames, data: *mut libc::c_void) -> libc::c_int
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -140,7 +140,7 @@ where
 
 unsafe extern "C" fn freewheel<N, P>(starting: libc::c_int, data: *mut libc::c_void)
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -150,7 +150,7 @@ where
 
 unsafe extern "C" fn buffer_size<N, P>(n_frames: Frames, data: *mut libc::c_void) -> libc::c_int
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -159,7 +159,7 @@ where
 
 unsafe extern "C" fn sample_rate<N, P>(n_frames: Frames, data: *mut libc::c_void) -> libc::c_int
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -171,7 +171,7 @@ unsafe extern "C" fn client_registration<N, P>(
     register: libc::c_int,
     data: *mut libc::c_void,
 ) where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -186,7 +186,7 @@ unsafe extern "C" fn port_registration<N, P>(
     register: libc::c_int,
     data: *mut libc::c_void,
 ) where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -203,7 +203,7 @@ unsafe extern "C" fn port_rename<N, P>(
     data: *mut libc::c_void,
 ) -> libc::c_int
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -220,7 +220,7 @@ unsafe extern "C" fn port_connect<N, P>(
     connect: libc::c_int,
     data: *mut libc::c_void,
 ) where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -231,7 +231,7 @@ unsafe extern "C" fn port_connect<N, P>(
 
 unsafe extern "C" fn graph_order<N, P>(data: *mut libc::c_void) -> libc::c_int
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -240,7 +240,7 @@ where
 
 unsafe extern "C" fn xrun<N, P>(data: *mut libc::c_void) -> libc::c_int
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     let ctx = CallbackContext::<N, P>::from_raw(data);
@@ -274,7 +274,7 @@ pub struct CallbackContext<N, P> {
 
 impl<N, P> CallbackContext<N, P>
 where
-    N: 'static + Send + Sync + NotificationHandler,
+    N: 'static + Send + NotificationHandler,
     P: 'static + Send + ProcessHandler,
 {
     pub unsafe fn from_raw<'a>(ptr: *mut libc::c_void) -> &'a mut CallbackContext<N, P> {

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -110,7 +110,7 @@ impl Client {
         process_handler: P,
     ) -> Result<AsyncClient<N, P>, Error>
     where
-        N: 'static + Send + Sync + NotificationHandler,
+        N: 'static + Send + NotificationHandler,
         P: 'static + Send + ProcessHandler,
     {
         AsyncClient::new(self, notification_handler, process_handler)


### PR DESCRIPTION
The `Sync` requirement on `NotificationHandler` is unecessary, and it is preventing me from storing an `mpsc::Sender` in my struct.