### PR TITLE
remove version specification for jack-sys in jack's Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,12 +8,12 @@ license = "MIT"
 name = "jack"
 readme = "README.md"
 repository = "https://github.com/RustAudio/rust-jack"
-version = "0.9.1"
+version = "0.9.2"
 
 [dependencies]
 bitflags = "1"
 dlib = "0.5"
-jack-sys = {path = "./jack-sys", version = "0.3.3"}
+jack-sys = {path = "./jack-sys"}
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"


### PR DESCRIPTION
jack 0.9.1 was published depending on jack-sys 0.3.3, which breaks
using the RUST_JACK_DLOPEN environment variable to activate the
dlopen feature. To fix this and avoid this error prone release
process, remove the version requirement in jack's Cargo.toml and
only use the relative path to jack-sys so they are always published
together.