### PR TITLE
Allow access to loaded `jack-sys` library

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.10.0
+
+- `load_jack_library()` now returns a reference to the loaded library
+
 ## 0.9.0
 
 - Jack library can be loaded dynamically from libjack.so.0 or libjack.dll.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "jack"
 readme = "README.md"
 repository = "https://github.com/RustAudio/rust-jack"
-version = "0.9.1"
+version = "0.10.0"
 
 [dependencies]
 bitflags = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,6 +92,9 @@ use lazy_static::lazy_static;
 #[cfg(feature = "metadata")]
 pub use crate::properties::*;
 
+/// Re-export of jack_sys, to ensure compatibility
+pub use jack_sys;
+
 /// Create and manage client connections to a JACK server.
 mod client;
 
@@ -140,10 +143,9 @@ lazy_static! {
 /// Dynamically loads the JACK library. This is libjack.so on Linux and
 /// libjack.dll on Windows.
 #[cfg(feature = "dlopen")]
-pub fn load_jack_library() -> Result<(), Error> {
+pub fn load_jack_library() -> Result<&'static jack_sys::JackLib, Error> {
     LIB_RESULT
         .as_ref()
-        .map(|_| ())
         .map_err(|e| Error::LoadLibraryError(format!("{}", e)))
 }
 


### PR DESCRIPTION
The dlopen feature made it impossible for downstream code to access the loaded library, which was previously possible by depending on `jack-sys` directly.  This commit alters `load_jack_library` to return its handle, and publicly re-exports the `jack-sys` crate.

This is a breaking change due to the altered signature of a public function.