### PR TITLE
Add introspection bindings and support for slow-sync clients

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -165,7 +165,7 @@ impl Transport {
     }
 
     //helper to convert to TransportState
-    fn state_from_ffi(state: j::jack_transport_state_t) -> TransportState {
+    pub(crate) fn state_from_ffi(state: j::jack_transport_state_t) -> TransportState {
         match state {
             j::JackTransportStopped => TransportState::Stopped,
             j::JackTransportStarting => TransportState::Starting,


### PR DESCRIPTION
This pull request contains two commits:
* The first adds bindings to inspect the state of the JACK server, such as enumerating the clients connected to a given port
* The second allows writing slow-sync clients.  As registering a sync handler at all changes JACK's behavior, this is gated by the new `ProcessHandler::SLOW_SYNC` constant.

I have been using these changes in my own project for a while now and they appear to work properly, but I don't know what unit tests should be added for them.