### PR TITLE
Return an error instead of panicking when the JACK library doesn't exist or couldn't be loaded

### DIFF
--- a/src/jack_enums.rs
+++ b/src/jack_enums.rs
@@ -3,6 +3,7 @@ use crate::ClientStatus;
 /// An error that can occur in JACK.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum Error {
+    LibraryError(String),
     CallbackDeregistrationError,
     CallbackRegistrationError,
     ClientActivationError,


### PR DESCRIPTION
This fixes #176. Check the issue for more details.
 