### PR TITLE
Only link necessary functions.

### DIFF
--- a/jack-sys/Cargo.toml
+++ b/jack-sys/Cargo.toml
@@ -6,7 +6,7 @@ license = "MIT OR Apache-2.0"
 links = "jack"
 name = "jack-sys"
 repository = "https://github.com/RustAudio/rust-jack/tree/main/jack-sys"
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 lazy_static = "1.4"

--- a/jack-sys/src/lib.rs
+++ b/jack-sys/src/lib.rs
@@ -10,9 +10,10 @@ mod functions {
 }
 
 pub use consts::*;
-pub use functions::dynamic_linking;
-pub use functions::dynamic_loading;
 pub use types::*;
+
+/// A dynamic loaded version of the API.
+pub use functions::dynamic_loading;
 
 #[cfg(not(feature = "dynamic_loading"))]
 pub use functions::dynamic_linking::*;

--- a/jack-sys/src/lib.rs
+++ b/jack-sys/src/lib.rs
@@ -12,9 +12,6 @@ mod functions {
 pub use consts::*;
 pub use types::*;
 
-/// A dynamic loaded version of the API.
-pub use functions::dynamic_loading;
-
 #[cfg(not(feature = "dynamic_loading"))]
 pub use functions::dynamic_linking::*;
 #[cfg(feature = "dynamic_loading")]


### PR DESCRIPTION
Makes it so that dynamic loading does not need to have the library dev files in order to compile.