### PR TITLE
Improve port debug output.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ license = "MIT"
 name = "jack"
 readme = "README.md"
 repository = "https://github.com/RustAudio/rust-jack"
-version = "0.11.1"
+version = "0.11.2"
 
 [dependencies]
 bitflags = "1"

--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -445,7 +445,7 @@ impl Client {
             j::jack_port_request_monitor_by_name(
                 self.raw(),
                 port_name_cstr.as_ptr(),
-                if enable_monitor { 1 } else { 0 },
+                i32::from(enable_monitor),
             )
         };
         match res {

--- a/src/port/port_impl.rs
+++ b/src/port/port_impl.rs
@@ -367,14 +367,12 @@ unsafe impl PortSpec for Unowned {
 impl<PS: PortSpec> Debug for Port<PS> {
     fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
         f.debug_struct("Port")
-            .field(
-                "name",
-                &self.name().unwrap_or_else(|e| format!("Error: {:?}", e)),
-            )
+            .field("name", &self.name())
             .field("connections", &self.connected_count().unwrap_or(0))
-            .field("port_type", &self.spec().jack_port_type())
+            .field("port_type", &self.port_type())
             .field("port_flags", &self.spec().jack_flags())
             .field("aliases", &self.aliases().unwrap_or_else(|_| Vec::new()))
+            .field("is_monitoring_input", &self.is_monitoring_input())
             .finish()
     }
 }

--- a/src/port/port_impl.rs
+++ b/src/port/port_impl.rs
@@ -167,7 +167,7 @@ impl<PS> Port<PS> {
     /// This only works if the port has the `CAN_MONITOR` flag set.
     pub fn request_monitor(&self, enable_monitor: bool) -> Result<(), Error> {
         self.check_client_life()?;
-        let onoff = if enable_monitor { 1 } else { 0 };
+        let onoff = i32::from(enable_monitor);
         let res = unsafe { j::jack_port_request_monitor(self.raw(), onoff) };
         match res {
             0 => Ok(()),
@@ -180,7 +180,7 @@ impl<PS> Port<PS> {
     /// nothing.
     pub fn ensure_monitor(&self, enable_monitor: bool) -> Result<(), Error> {
         self.check_client_life()?;
-        let onoff = if enable_monitor { 1 } else { 0 };
+        let onoff = i32::from(enable_monitor);
         let res = unsafe { j::jack_port_ensure_monitor(self.raw(), onoff) };
         match res {
             0 => Ok(()),

--- a/src/port/test_port.rs
+++ b/src/port/test_port.rs
@@ -178,11 +178,11 @@ fn port_debug_printing() {
     p.set_alias("this_port_alias").unwrap();
     let got = format!("{:?}", p);
     let parts = [
-        ("name", "\"port_has_debug_string:debug_info\""),
+        ("name", "Ok(\"port_has_debug_string:debug_info\")"),
         ("connections", "0"),
-        ("port_type", "\"32 bit float mono audio\""),
+        ("port_type", "Ok(\"32 bit float mono audio\")"),
         ("port_flags", "IS_INPUT"),
-        ("aliases", "[\"this_port_alias\"]"),
+        ("aliases", "[\"this_port_alias\""),
     ];
     for &(k, v) in parts.iter() {
         let p = format!("{}: {}", k, v);

--- a/src/properties.rs
+++ b/src/properties.rs
@@ -240,7 +240,7 @@ mod metadata {
                 if cnt > 0 {
                     let descriptions = descriptions.assume_init();
                     for des in std::slice::from_raw_parts_mut(descriptions, cnt as usize) {
-                        let uuid = (*des).subject;
+                        let uuid = (des).subject;
                         if let Some(dmap) = description_to_map_free(des) {
                             map.insert(uuid, dmap);
                         }


### PR DESCRIPTION
Uses port type from JACK instead of from the spec and adds is_monitoring field.