### PR TITLE
best effort close client

### DIFF
--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -658,9 +658,9 @@ impl Drop for Client {
         debug_assert!(!self.raw().is_null()); // Rep invariant
                                               // Close the client
         sleep_on_test();
-        let res = unsafe { j::jack_client_close(self.raw()) }; // close the client
+        let _res = unsafe { j::jack_client_close(self.raw()) }; // best effort: close the client
         sleep_on_test();
-        assert_eq!(res, 0);
+        //assert_eq!(res, 0); //do not assert here. connection could be broken
         self.0 = ptr::null_mut();
     }
 }


### PR DESCRIPTION
Remove assert that connection closing is successful. 

If the jack server is shutdown/restarted while the client connection is up then the closing will fail and you get a thread panic from the assert. 

Furthermore the whole client is forever "bricked" since the assert will happen while holding the CREATE_OR_DESTROY_CLIENT_MUTEX.lock(). The mutex will get a PoisonError which prevents a new client connection to be created again. The mutex is a lazy_static "singleton" so it prevents ANY client to be created for the duration of the application. 