### PR TITLE
silence logs before connected

### DIFF
--- a/src/client/client_impl.rs
+++ b/src/client/client_impl.rs
@@ -59,8 +59,8 @@ impl Client {
         }
 
         unsafe {
-            jack_sys::jack_set_error_function(Some(error_handler));
-            jack_sys::jack_set_info_function(Some(info_handler));
+            jack_sys::jack_set_error_function(Some(silent_handler));
+            jack_sys::jack_set_info_function(Some(silent_handler));
         }
         sleep_on_test();
         let mut status_bits = 0;
@@ -73,6 +73,11 @@ impl Client {
         if client.is_null() {
             Err(Error::ClientError(status))
         } else {
+            unsafe {
+                jack_sys::jack_set_error_function(Some(error_handler));
+                jack_sys::jack_set_info_function(Some(info_handler));
+            }
+            sleep_on_test();
             Ok((Client(client, Arc::default(), None), status))
         }
     }
@@ -787,4 +792,8 @@ unsafe extern "C" fn info_handler(msg: *const libc::c_char) {
         Ok(msg) => log::info!("{}", msg),
         Err(err) => log::error!("failed to parse JACK error: {:?}", err),
     }
+}
+
+unsafe extern "C" fn silent_handler(_msg: *const libc::c_char) {
+    //silent
 }


### PR DESCRIPTION
Move error and info logs printouts to after we have connected the client.

Before this change the console was spammed with error logs if the connection(s) failed with no way to silence it. 

The return Result from the connection attempt could be used to catch the failure and then you can print something, if desired. Else it should be quiet. 